### PR TITLE
Typst source file support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,9 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
+escape-bytes = "0.1.1"
 pulldown-cmark = { version = "0.12.2", default-features = false, features = ["html"] }
 pulldown-cmark-to-cmark = "20.0.0"
-quick-xml = "0.37.2"
+regex = "1.11.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
 escape-bytes = "0.1.1"
+fancy-regex = "0.14.0"
 pulldown-cmark = { version = "0.12.2", default-features = false, features = ["html"] }
 pulldown-cmark-to-cmark = "20.0.0"
 regex = "1.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 clap = { version = "4.5.23", features = ["derive"] }
 pulldown-cmark = { version = "0.12.2", default-features = false, features = ["html"] }
 pulldown-cmark-to-cmark = "20.0.0"
+quick-xml = "0.37.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -7,7 +7,7 @@ pub mod taxon;
 pub mod typst;
 pub mod writer;
 
-use std::{ffi::OsStr, fmt::Debug, path::Path};
+use std::{fmt::Debug, path::Path};
 
 use parser::parse_markdown;
 use section::{HTMLContent, ShallowSection};
@@ -29,12 +29,9 @@ pub enum CompileError {
 
 pub fn compile_all(workspace_dir: &str) -> Result<(), CompileError> {
     let mut state = CompileState::new();
+    let workspace = all_source_files(Path::new(workspace_dir)).unwrap();
 
-    fn compile_filetype<F: Fn() -> Result<ShallowSection, CompileError>>(
-        slug: &str,
-        ext: &str,
-        parse: F,
-    ) -> Result<ShallowSection, CompileError> {
+    for (slug, ext) in &workspace.slug_exts {
         let relative_path = format!("{}.{}", slug, ext);
 
         let is_modified = verify_and_file_hash(&relative_path).map_err(|e| {
@@ -57,7 +54,11 @@ pub fn compile_all(workspace_dir: &str) -> Result<(), CompileError> {
             let shallow: ShallowSection = serde_json::from_str(&serialized).unwrap();
             shallow
         } else {
-            let shallow = parse()?;
+            let shallow = match ext.as_str() {
+                "md" => parse_markdown(slug)?,
+                "typst" => parse_typst(slug, workspace_dir)?,
+                _ => panic!(),
+            };
             let serialized = serde_json::to_string(&shallow).unwrap();
             std::fs::write(entry_path_buf, serialized).map_err(|e| {
                 CompileError::IO(Some(concat!(file!(), '#', line!())), e, entry_path_str)
@@ -66,24 +67,15 @@ pub fn compile_all(workspace_dir: &str) -> Result<(), CompileError> {
             shallow
         };
 
-        Ok(shallow)
-    }
-
-    let workspace = all_files(Path::new(workspace_dir), is_markdown).unwrap();
-    for slug in &workspace.slugs {
-        let shallow = compile_filetype(slug, "md", || parse_markdown(slug))?;
-        state.residued.insert(slug.to_string(), shallow);
-    }
-
-    let workspace = all_files(Path::new(workspace_dir), is_typst).unwrap();
-    for slug in &workspace.slugs {
-        let shallow = compile_filetype(slug, "typst", || parse_typst(slug, workspace_dir))?;
         state.residued.insert(slug.to_string(), shallow);
     }
 
     state.compile_all();
 
-    Writer::write_needed_slugs(&workspace.slugs, &state);
+    Writer::write_needed_slugs(
+        &workspace.slug_exts.into_iter().map(|x| x.0).collect(),
+        &state,
+    );
 
     Ok(())
 }
@@ -98,40 +90,36 @@ pub fn should_ignored_dir(path: &Path) -> bool {
     name == config::CACHE_DIR_NAME
 }
 
-pub fn is_markdown(path: &Path) -> bool {
-    path.extension() == Some(OsStr::new("md"))
-}
-
-pub fn is_typst(path: &Path) -> bool {
-    path.extension() == Some(OsStr::new("typst"))
+pub fn is_source(path: &Path) -> bool {
+    path.extension()
+        .and_then(|s| s.to_str())
+        .map(|s| matches!(s, "md" | "typst"))
+        .unwrap_or(false)
 }
 
 /**
  * collect all source file paths in workspace dir
  */
-pub fn all_files<F: Fn(&Path) -> bool>(
-    root_dir: &Path,
-    predicate: F,
-) -> Result<Workspace, Box<std::io::Error>> {
+pub fn all_source_files(root_dir: &Path) -> Result<Workspace, Box<std::io::Error>> {
     let root_dir = root_dir.to_str().unwrap();
     let offset = root_dir.len();
-    let mut slugs: Vec<String> = vec![];
-    let to_slug = |s: String| slug::to_slug(&s[offset..]);
+    let mut slug_exts = vec![];
+    let to_slug_ext = |s: String| slug::to_slug_ext(&s[offset..]);
 
     for entry in std::fs::read_dir(root_dir)? {
         let path = entry?.path();
-        if path.is_file() && predicate(&path) && !should_ignored_file(&path) {
+        if path.is_file() && is_source(&path) && !should_ignored_file(&path) {
             let path = posix_style(path.to_str().unwrap());
-            slugs.push(to_slug(path));
+            slug_exts.push(to_slug_ext(path));
         } else if path.is_dir() && !should_ignored_dir(&path) {
-            files_match_with(&path, &predicate, &mut slugs, &to_slug)?;
+            files_match_with(&path, &is_source, &mut slug_exts, &to_slug_ext)?;
         }
     }
 
-    Ok(Workspace { slugs })
+    Ok(Workspace { slug_exts })
 }
 
 #[derive(Debug)]
 pub struct Workspace {
-    pub slugs: Vec<String>,
+    pub slug_exts: Vec<(String, String)>,
 }

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -3,8 +3,7 @@ use std::{collections::HashMap, vec};
 use pulldown_cmark::{html, CowStr, Event, Options, Tag, TagEnd};
 
 use crate::{
-    config::input_path, entry::EntryMetaData, process::processer::Processer,
-    recorder::ParseRecorder,
+    config::input_path, entry::HTMLMetaData, process::processer::Processer, recorder::ParseRecorder,
 };
 
 use super::{
@@ -20,11 +19,11 @@ pub const OPTIONS: Options = Options::ENABLE_MATH
 
 pub fn initialize(
     slug: &str,
-) -> Result<(String, HashMap<String, String>, ParseRecorder), CompileError> {
+) -> Result<(String, HashMap<String, HTMLContent>, ParseRecorder), CompileError> {
     // global data store
-    let mut metadata: HashMap<String, String> = HashMap::new();
+    let mut metadata: HashMap<String, HTMLContent> = HashMap::new();
     let fullname = format!("{}.md", slug);
-    metadata.insert("slug".to_string(), slug.to_string());
+    metadata.insert("slug".to_string(), HTMLContent::Plain(slug.to_string()));
 
     // local contents recorder
     let markdown_path = input_path(&fullname);
@@ -56,7 +55,7 @@ pub fn parse_markdown(slug: &str) -> Result<ShallowSection, CompileError> {
         &mut processers,
         false,
     )?;
-    let metadata = EntryMetaData(metadata);
+    let metadata = HTMLMetaData(metadata);
 
     return Ok(ShallowSection {
         metadata,
@@ -64,51 +63,11 @@ pub fn parse_markdown(slug: &str) -> Result<ShallowSection, CompileError> {
     });
 }
 
-pub fn cmark_to_html(markdown_input: &str, ignore_paragraph: bool) -> String {
-    
-    let mut recorder = ParseRecorder::new("cmark_to_html".to_owned());
-    let mut processers: Vec<Box<dyn Processer>> = vec![
-        Box::new(crate::process::katex_compat::KatexCompact),
-    ];
-
-    let parser = pulldown_cmark::Parser::new_ext(&markdown_input, OPTIONS);
-    let parser = parser.filter_map(|event| match &event {
-        Event::Start(tag) => match tag {
-            Tag::Paragraph if ignore_paragraph => None,
-            _ => Some(event),
-        },
-        Event::End(tag) => match tag {
-            TagEnd::Paragraph if ignore_paragraph => None,
-            _ => Some(event),
-        },
-        Event::InlineMath(s) => {
-            let mut html = String::new();
-            processers.iter_mut().for_each(|handler| {
-                handler.inline_math(&s, &mut recorder).map(|s| html = s);
-            });
-            Some(Event::Html(CowStr::Boxed(html.into())))
-        },
-        Event::DisplayMath(s) => {
-            let mut html = String::new();
-            processers.iter_mut().for_each(|handler| {
-                handler.display_math(&s, &mut recorder).map(|s| html = s);
-            });
-            Some(Event::Html(CowStr::Boxed(html.into())))
-        },
-        _ => Some(event),
-    });
-    let mut html_output = String::new();
-    html::push_html(&mut html_output, parser);
-    html_output
-}
-
 pub fn parse_spanned_markdown(
     markdown_input: &str,
     current_slug: &str,
-) -> Result<ShallowSection, CompileError> {
+) -> Result<HTMLContent, CompileError> {
     let mut recorder = ParseRecorder::new(current_slug.to_owned());
-    let mut metadata = HashMap::new();
-    metadata.insert("slug".to_string(), format!("{}:metadata", current_slug));
 
     let mut processers: Vec<Box<dyn Processer>> = vec![
         Box::new(crate::process::typst_image::TypstImage),
@@ -119,20 +78,17 @@ pub fn parse_spanned_markdown(
     let content = parse_content(
         &markdown_input,
         &mut recorder,
-        &mut metadata,
+        &mut HashMap::new(),
         &mut processers,
         true,
     )?;
-    return Ok(ShallowSection {
-        metadata: EntryMetaData(metadata),
-        content,
-    });
+    return Ok(content);
 }
 
 pub fn parse_content(
     markdown_input: &str,
     recorder: &mut ParseRecorder,
-    metadata: &mut HashMap<String, String>,
+    metadata: &mut HashMap<String, HTMLContent>,
     processers: &mut Vec<Box<dyn Processer>>,
     ignore_paragraph: bool,
 ) -> Result<HTMLContent, CompileError> {
@@ -182,9 +138,13 @@ pub fn parse_content(
             }
 
             Event::Text(s) => {
-                processers
-                    .iter_mut()
-                    .for_each(|handler| handler.text(s, recorder, metadata));
+                for handler in processers.iter_mut() {
+                    handler.text(s, recorder, metadata)?;
+                }
+                // processers
+                //     .iter_mut()
+                //     .map(|handler| handler.text(s, recorder, metadata))
+                //     .collect::<Result<(), _>>()?;
             }
 
             Event::InlineMath(s) => {

--- a/src/compiler/typst.rs
+++ b/src/compiler/typst.rs
@@ -1,8 +1,10 @@
-use super::section::HTMLContentBuilder;
-use super::{section::LazyContent, CompileError, ShallowSection};
+use super::section::{HTMLContent, HTMLContentBuilder, LazyContent};
+use super::{CompileError, ShallowSection};
 use crate::compiler::section::{EmbedContent, LocalLink, SectionOption};
-use crate::{entry::EntryMetaData, typst_cli};
-use regex::Regex;
+use crate::entry::HTMLMetaData;
+use crate::slug::to_slug;
+use crate::typst_cli;
+use fancy_regex::Regex;
 use std::collections::HashMap;
 use std::str;
 
@@ -14,36 +16,44 @@ fn process_bool(m: Option<&String>, def: bool) -> bool {
     }
 }
 
-pub fn parse_typst(slug: &str, root_dir: &str) -> Result<ShallowSection, CompileError> {
-    let relative_path = format!("{}.typst", slug);
-    let html_str = typst_cli::file_to_html(&relative_path, root_dir).map_err(|e| {
-        CompileError::IO(
-            Some(concat!(file!(), '#', line!())),
-            e,
-            relative_path.to_string(),
-        )
-    })?;
+fn parse_typst_html(
+    html_str: &str,
+    relative_path: &str,
+    metadata: &mut HashMap<String, HTMLContent>,
+) -> Result<HTMLContent, CompileError> {
+    let mut builder = HTMLContentBuilder::new();
     let mut cursor: usize = 0;
 
-    let mut metadata = HashMap::new();
-    metadata.insert("slug".to_string(), slug.to_string());
-    let mut builder = HTMLContentBuilder::new();
-
-    let re_kodama = Regex::new(
-        r#"<kodama(?<attrs>(\s+([a-zA-Z]+)="([^"\\]|\\[\s\S])*")*)>(?<inner>[\s\S]*?)</kodama>"#,
-    )
+    let pre_kodama = |tags: &str, alt: u8| {
+        format!(
+            r#"<kodama(?<tag{}>{})(?<attrs{}>(\s+([a-zA-Z]+)="([^"\\]|\\[\s\S])*")*)>(?<inner{}>[\s\S]*?)</kodama(?P=tag{})>"#,
+            alt, tags, alt, alt, alt
+        )
+    };
+    let re_kodama = Regex::new(&format!(
+        "<span>{}</span>|{}",
+        pre_kodama("local", 0),
+        pre_kodama("meta|embed|local", 1)
+    ))
     .unwrap();
+    // println!("{}", re_kodama);
     let re_attrs = Regex::new(r#"(?<key>[a-zA-Z]+)="(?<value>([^"\\]|\\[\s\S])*)""#).unwrap();
 
-    for capture in re_kodama.captures_iter(&html_str) {
+    for capture in re_kodama.captures_iter(&html_str).map(Result::unwrap) {
         let all = capture.get(0).unwrap();
+        let get_capture = |name: &str| {
+            capture
+                .name(&format!("{}0", name))
+                .or(capture.name(&format!("{}1", name)))
+        };
 
         builder.push_str(&html_str[cursor..all.start()]);
         cursor = all.end();
 
-        let attrs_str = capture.name("attrs").unwrap().as_str();
+        let attrs_str = get_capture("attrs").unwrap().as_str();
         let attrs: HashMap<&str, String> = re_attrs
             .captures_iter(attrs_str)
+            .map(Result::unwrap)
             .map(|c| {
                 (
                     c.name("key").unwrap().as_str(),
@@ -65,26 +75,35 @@ pub fn parse_typst(slug: &str, root_dir: &str) -> Result<ShallowSection, Compile
             ))
         };
 
-        let value = attrs.get("value").map_or_else(
-            || capture.name("inner").unwrap().as_str().trim().to_string(),
-            ToString::to_string,
-        );
-        fn str_opt(value: String) -> Option<String> {
+        let value = || {
+            let value = attrs.get("value").map_or_else(
+                || get_capture("inner").unwrap().as_str().trim().to_string(),
+                |s| s.to_string(),
+            );
             if value.is_empty() {
                 None
             } else {
                 Some(value)
             }
-        }
-        match attr("type")?.as_ref() {
+        };
+        match get_capture("tag").unwrap().as_str() {
             "meta" => {
-                metadata.insert(attr("key")?.to_string(), value);
+                let content = if let Some(value) = attrs.get("value") {
+                    HTMLContent::Plain(value.to_string())
+                } else {
+                    parse_typst_html(
+                        get_capture("inner").unwrap().as_str().trim(),
+                        relative_path,
+                        &mut HashMap::new(),
+                    )?
+                };
+                metadata.insert(attr("key")?.to_string(), content);
             }
             "embed" => {
                 let def = SectionOption::default();
 
                 let url = attr("url")?.to_string();
-                let title = str_opt(value);
+                let title = value();
                 let numbering = process_bool(attrs.get("numbering"), def.numbering);
                 let details_open = process_bool(attrs.get("open"), def.details_open);
                 let catalog = process_bool(attrs.get("catalog"), def.catalog);
@@ -95,15 +114,15 @@ pub fn parse_typst(slug: &str, root_dir: &str) -> Result<ShallowSection, Compile
                 }))
             }
             "local" => {
-                let slug = attr("slug")?.to_string();
-                let text = str_opt(value);
+                let slug = to_slug(attr("slug")?);
+                let text = value();
                 builder.push(LazyContent::Local(LocalLink { slug, text }))
             }
             tag => {
                 return Err(CompileError::Syntax(
                     Some(concat!(file!(), '#', line!())),
                     Box::new(format!("Unknown kodama element type {}", tag)),
-                    relative_path,
+                    relative_path.to_string(),
                 ))
             }
         }
@@ -111,8 +130,26 @@ pub fn parse_typst(slug: &str, root_dir: &str) -> Result<ShallowSection, Compile
 
     builder.push_str(&html_str[cursor..]);
 
+    Ok(builder.build())
+}
+
+pub fn parse_typst(slug: &str, root_dir: &str) -> Result<ShallowSection, CompileError> {
+    let relative_path = format!("{}.typst", slug);
+    let html_str = typst_cli::file_to_html(&relative_path, root_dir).map_err(|e| {
+        CompileError::IO(
+            Some(concat!(file!(), '#', line!())),
+            e,
+            relative_path.to_string(),
+        )
+    })?;
+
+    let mut metadata: HashMap<String, HTMLContent> = HashMap::new();
+    metadata.insert("slug".to_string(), HTMLContent::Plain(slug.to_string()));
+
+    let content = parse_typst_html(&html_str, &relative_path, &mut metadata)?;
+
     Ok(ShallowSection {
-        metadata: EntryMetaData(metadata),
-        content: builder.build(),
+        metadata: HTMLMetaData(metadata),
+        content,
     })
 }

--- a/src/compiler/typst.rs
+++ b/src/compiler/typst.rs
@@ -1,73 +1,91 @@
-use std::borrow::Cow;
-use std::cell::RefCell;
+use super::{section::LazyContent, CompileError, HTMLContent, ShallowSection};
+use crate::compiler::section::{EmbedContent, LocalLink, SectionOption};
+use crate::{entry::EntryMetaData, typst_cli};
+use regex::Regex;
 use std::str;
 use std::{collections::HashMap, vec};
 
-use quick_xml::events::{BytesStart, Event};
-use quick_xml::reader::Reader;
-
-use crate::compiler::section::{EmbedContent, LocalLink, SectionOption};
-use crate::{entry::EntryMetaData, typst_cli::source_to_html_inplace};
-
-use super::{section::LazyContent, CompileError, HTMLContent, ShallowSection};
-
-fn is_positive(s: Cow<'_, str>) -> bool {
-    !matches!(s.as_ref(), "false" | "0" | "none")
+fn process_bool(m: Option<&String>, def: bool) -> bool {
+    match m.map(String::as_str) {
+        None | Some("auto") => def,
+        Some("false") | Some("0") | Some("none") => false,
+        _ => true,
+    }
 }
 
 pub fn parse_typst(slug: &str, root_dir: &str) -> Result<ShallowSection, CompileError> {
     let relative_path = format!("{}.typst", slug);
-    let html_str = source_to_html_inplace(&relative_path, root_dir).map_err(|e| {
+    let html_str = typst_cli::file_to_html(&relative_path, root_dir).map_err(|e| {
         CompileError::IO(
             Some(concat!(file!(), '#', line!())),
             e,
             relative_path.to_string(),
         )
     })?;
+    let mut cursor: usize = 0;
 
     let mut metadata = HashMap::new();
     metadata.insert("slug".to_string(), slug.to_string());
     let mut contents = vec![];
-    let content = RefCell::new(String::new());
+    let mut content = String::new();
 
-    let mut tag_kodama = |e: BytesStart| {
-        let mattr = |attr_name: &str| {
-            e.try_get_attribute(attr_name)
-                .map_err(|e| {
-                    CompileError::Syntax(
-                        Some(concat!(file!(), '#', line!())),
-                        Box::new(e),
-                        relative_path.to_string(),
+    let re_kodama =
+        Regex::new(r#"<kodama((\s+([a-zA-Z]+)="([^"\\]|\\[\s\S])*")*)>([\s\S]*?)</kodama>"#)
+            .unwrap();
+    let re_attrs = Regex::new(r#"([a-zA-Z]+)="(([^"\\]|\\[\s\S])*)""#).unwrap();
+
+    for capture in re_kodama.captures_iter(&html_str) {
+        let all = capture.get(0).unwrap();
+
+        content.push_str(&html_str[cursor..all.start()]);
+        cursor = all.end();
+
+        let attrs_str = capture.get(1).unwrap().as_str();
+        let attrs: HashMap<&str, String> = re_attrs
+            .captures_iter(attrs_str)
+            .map(|c| {
+                (
+                    c.get(1).unwrap().as_str(),
+                    String::from_utf8_lossy(
+                        escape_bytes::unescape(c.get(2).unwrap().as_str().as_bytes())
+                            .unwrap()
+                            .as_slice(),
                     )
-                })
-                .map(|o| o.map(|a| a.unescape_value().unwrap()))
-        };
+                    .into_owned(),
+                )
+            })
+            .collect();
+
         let attr = |attr_name: &str| {
-            mattr(attr_name)?.ok_or(CompileError::Syntax(
+            attrs.get(attr_name).ok_or(CompileError::Syntax(
                 Some(concat!(file!(), '#', line!())),
-                Box::new(format!(
-                    "No attribute named {} in tag {}",
-                    attr_name,
-                    &String::from_utf8_lossy(e.name().0)
-                )),
+                Box::new(format!("No attribute '{}' in tag kodama", attr_name)),
                 relative_path.to_string(),
             ))
         };
+
+        let inner = capture.get(5).unwrap().as_str().trim();
         match attr("type")?.as_ref() {
             "meta" => {
-                metadata.insert(attr("key")?.to_string(), attr("value")?.to_string());
+                metadata.insert(attr("key")?.to_string(), inner.to_string());
             }
             "embed" => {
-                if !content.borrow().is_empty() {
-                    contents.push(LazyContent::Plain(content.take()));
+                if !content.is_empty() {
+                    contents.push(LazyContent::Plain(content));
+                    content = String::new();
                 }
 
                 let def = SectionOption::default();
+
                 let url = attr("url")?.to_string();
-                let title = mattr("title")?.map(|s| s.to_string());
-                let numbering = mattr("numbering")?.map_or(def.numbering, is_positive);
-                let details_open = mattr("open")?.map_or(def.details_open, is_positive);
-                let catalog = mattr("catalog")?.map_or(def.catalog, is_positive);
+                let title = if inner == "" {
+                    None
+                } else {
+                    Some(inner.to_string())
+                };
+                let numbering = process_bool(attrs.get("numbering"), def.numbering);
+                let details_open = process_bool(attrs.get("open"), def.details_open);
+                let catalog = process_bool(attrs.get("catalog"), def.catalog);
                 contents.push(LazyContent::Embed(EmbedContent {
                     url,
                     title,
@@ -75,12 +93,17 @@ pub fn parse_typst(slug: &str, root_dir: &str) -> Result<ShallowSection, Compile
                 }))
             }
             "local" => {
-                if !content.borrow().is_empty() {
-                    contents.push(LazyContent::Plain(content.take()));
+                if !content.is_empty() {
+                    contents.push(LazyContent::Plain(content));
+                    content = String::new();
                 }
 
                 let slug = attr("slug")?.to_string();
-                let text = mattr("text")?.map(|s| s.to_string());
+                let text = if inner == "" {
+                    None
+                } else {
+                    Some(inner.to_string())
+                };
                 contents.push(LazyContent::Local(LocalLink { slug, text }))
             }
             tag => {
@@ -91,60 +114,12 @@ pub fn parse_typst(slug: &str, root_dir: &str) -> Result<ShallowSection, Compile
                 ))
             }
         }
-        Ok(())
-    };
-
-    let mut reader = Reader::from_str(&html_str);
-    reader.config_mut().trim_text(true);
-    loop {
-        match reader.read_event() {
-            Err(e) => {
-                return Err(CompileError::Syntax(
-                    Some(concat!(file!(), '#', line!())),
-                    Box::new(format!(
-                        "Error at position {}: {:?}",
-                        reader.error_position(),
-                        e
-                    )),
-                    relative_path.to_string(),
-                ))
-            }
-            Ok(Event::Eof) => break,
-
-            Ok(Event::Start(e)) => match e.name().as_ref() {
-                b"kodama" => tag_kodama(e)?,
-                b"html" | b"body" => (),
-                _ => content
-                    .borrow_mut()
-                    .push_str(&format!("<{}>", String::from_utf8_lossy(&e.to_vec()))),
-            },
-            Ok(Event::Empty(e)) => match e.name().as_ref() {
-                b"kodama" => tag_kodama(e)?,
-                b"html" | b"body" => (),
-                _ => content
-                    .borrow_mut()
-                    .push_str(&format!("<{}/>", String::from_utf8_lossy(&e.to_vec()))),
-            },
-            Ok(Event::End(e)) => match e.name().as_ref() {
-                b"kodama" => (),
-                b"html" | b"body" => (),
-                _ => content
-                    .borrow_mut()
-                    .push_str(&format!("</{}>", String::from_utf8_lossy(&e.to_vec()))),
-            },
-            Ok(Event::Comment(e)) => content
-                .borrow_mut()
-                .push_str(&format!("<!--{}-->", String::from_utf8_lossy(&e.to_vec()))),
-            Ok(Event::Text(e)) => content
-                .borrow_mut()
-                .push_str(&String::from_utf8_lossy(&e.to_vec())),
-
-            _ => (),
-        }
     }
 
-    if !content.borrow().is_empty() {
-        contents.push(LazyContent::Plain(content.take()));
+    content.push_str(&html_str[cursor..]);
+
+    if !content.is_empty() {
+        contents.push(LazyContent::Plain(content));
     }
 
     if contents.len() == 1 {

--- a/src/compiler/typst.rs
+++ b/src/compiler/typst.rs
@@ -1,0 +1,163 @@
+use std::borrow::Cow;
+use std::cell::RefCell;
+use std::str;
+use std::{collections::HashMap, vec};
+
+use quick_xml::events::{BytesStart, Event};
+use quick_xml::reader::Reader;
+
+use crate::compiler::section::{EmbedContent, LocalLink, SectionOption};
+use crate::{entry::EntryMetaData, typst_cli::source_to_html_inplace};
+
+use super::{section::LazyContent, CompileError, HTMLContent, ShallowSection};
+
+fn is_positive(s: Cow<'_, str>) -> bool {
+    !matches!(s.as_ref(), "false" | "0" | "none")
+}
+
+pub fn parse_typst(slug: &str, root_dir: &str) -> Result<ShallowSection, CompileError> {
+    let relative_path = format!("{}.typst", slug);
+    let html_str = source_to_html_inplace(&relative_path, root_dir).map_err(|e| {
+        CompileError::IO(
+            Some(concat!(file!(), '#', line!())),
+            e,
+            relative_path.to_string(),
+        )
+    })?;
+
+    let mut metadata = HashMap::new();
+    metadata.insert("slug".to_string(), slug.to_string());
+    let mut contents = vec![];
+    let content = RefCell::new(String::new());
+
+    let mut tag_kodama = |e: BytesStart| {
+        let mattr = |attr_name: &str| {
+            e.try_get_attribute(attr_name)
+                .map_err(|e| {
+                    CompileError::Syntax(
+                        Some(concat!(file!(), '#', line!())),
+                        Box::new(e),
+                        relative_path.to_string(),
+                    )
+                })
+                .map(|o| o.map(|a| a.unescape_value().unwrap()))
+        };
+        let attr = |attr_name: &str| {
+            mattr(attr_name)?.ok_or(CompileError::Syntax(
+                Some(concat!(file!(), '#', line!())),
+                Box::new(format!(
+                    "No attribute named {} in tag {}",
+                    attr_name,
+                    &String::from_utf8_lossy(e.name().0)
+                )),
+                relative_path.to_string(),
+            ))
+        };
+        match attr("type")?.as_ref() {
+            "meta" => {
+                metadata.insert(attr("key")?.to_string(), attr("value")?.to_string());
+            }
+            "embed" => {
+                if !content.borrow().is_empty() {
+                    contents.push(LazyContent::Plain(content.take()));
+                }
+
+                let def = SectionOption::default();
+                let url = attr("url")?.to_string();
+                let title = mattr("title")?.map(|s| s.to_string());
+                let numbering = mattr("numbering")?.map_or(def.numbering, is_positive);
+                let details_open = mattr("open")?.map_or(def.details_open, is_positive);
+                let catalog = mattr("catalog")?.map_or(def.catalog, is_positive);
+                contents.push(LazyContent::Embed(EmbedContent {
+                    url,
+                    title,
+                    option: SectionOption::new(numbering, details_open, catalog),
+                }))
+            }
+            "local" => {
+                if !content.borrow().is_empty() {
+                    contents.push(LazyContent::Plain(content.take()));
+                }
+
+                let slug = attr("slug")?.to_string();
+                let text = mattr("text")?.map(|s| s.to_string());
+                contents.push(LazyContent::Local(LocalLink { slug, text }))
+            }
+            tag => {
+                return Err(CompileError::Syntax(
+                    Some(concat!(file!(), '#', line!())),
+                    Box::new(format!("Unknown kodama element type {}", tag)),
+                    relative_path.to_string(),
+                ))
+            }
+        }
+        Ok(())
+    };
+
+    let mut reader = Reader::from_str(&html_str);
+    reader.config_mut().trim_text(true);
+    loop {
+        match reader.read_event() {
+            Err(e) => {
+                return Err(CompileError::Syntax(
+                    Some(concat!(file!(), '#', line!())),
+                    Box::new(format!(
+                        "Error at position {}: {:?}",
+                        reader.error_position(),
+                        e
+                    )),
+                    relative_path.to_string(),
+                ))
+            }
+            Ok(Event::Eof) => break,
+
+            Ok(Event::Start(e)) => match e.name().as_ref() {
+                b"kodama" => tag_kodama(e)?,
+                b"html" | b"body" => (),
+                _ => content
+                    .borrow_mut()
+                    .push_str(&format!("<{}>", String::from_utf8_lossy(&e.to_vec()))),
+            },
+            Ok(Event::Empty(e)) => match e.name().as_ref() {
+                b"kodama" => tag_kodama(e)?,
+                b"html" | b"body" => (),
+                _ => content
+                    .borrow_mut()
+                    .push_str(&format!("<{}/>", String::from_utf8_lossy(&e.to_vec()))),
+            },
+            Ok(Event::End(e)) => match e.name().as_ref() {
+                b"kodama" => (),
+                b"html" | b"body" => (),
+                _ => content
+                    .borrow_mut()
+                    .push_str(&format!("</{}>", String::from_utf8_lossy(&e.to_vec()))),
+            },
+            Ok(Event::Comment(e)) => content
+                .borrow_mut()
+                .push_str(&format!("<!--{}-->", String::from_utf8_lossy(&e.to_vec()))),
+            Ok(Event::Text(e)) => content
+                .borrow_mut()
+                .push_str(&String::from_utf8_lossy(&e.to_vec())),
+
+            _ => (),
+        }
+    }
+
+    if !content.borrow().is_empty() {
+        contents.push(LazyContent::Plain(content.take()));
+    }
+
+    if contents.len() == 1 {
+        if let LazyContent::Plain(html) = &contents[0] {
+            return Ok(ShallowSection {
+                metadata: EntryMetaData(metadata),
+                content: HTMLContent::Plain(html.to_string()),
+            });
+        }
+    }
+
+    Ok(ShallowSection {
+        metadata: EntryMetaData(metadata),
+        content: HTMLContent::Lazy(contents),
+    })
+}

--- a/src/compiler/writer.rs
+++ b/src/compiler/writer.rs
@@ -3,6 +3,7 @@ use std::{collections::HashSet, ops::Not, path::Path};
 use crate::{
     compiler::counter::Counter,
     config::{self, verify_update_hash},
+    entry::MetaData,
     html,
     html_flake::{self, html_article_inner},
 };
@@ -63,11 +64,7 @@ impl Writer {
 
         let callback = state.callback.0.get(&slug);
         let footer_html = Writer::footer(state, &section.references, callback);
-        let page_title = section
-            .metadata
-            .get("page-title")
-            .map(|s| s.as_str())
-            .unwrap_or_else(|| section.metadata.title().map_or("", |s| s));
+        let page_title = section.metadata.page_title().map_or("", |s| s.as_str());
 
         let html = crate::html_flake::html_doc(
             &page_title,
@@ -90,7 +87,8 @@ impl Writer {
                 state.compiled.get(parent).map(|section| {
                     let href = config::full_html_url(parent);
                     let title = section.metadata.title().map_or("", |s| s);
-                    html_flake::html_header_nav(title, &href)
+                    let page_title = section.metadata.page_title().map_or("", |s| s);
+                    html_flake::html_header_nav(title, page_title, &href)
                 })
             })
             .unwrap_or_default()
@@ -150,7 +148,15 @@ impl Writer {
     fn catalog_item(section: &Section, taxon: &str, child_html: &str) -> String {
         let slug = &section.slug();
         let text = section.metadata.title().map_or("", |s| s);
-        html_flake::catalog_item(slug, text, section.option.details_open, taxon, child_html)
+        let page_title = section.metadata.page_title().map_or("", |s| s);
+        html_flake::catalog_item(
+            slug,
+            text,
+            page_title,
+            section.option.details_open,
+            taxon,
+            child_html,
+        )
     }
 
     fn footer_content_to_html(content: &SectionContent) -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -279,15 +279,15 @@ pub fn verify_update_hash(path: &str, content: &str) -> Result<bool, std::io::Er
     Ok(is_modified)
 }
 
-pub fn files_match_with<F, G>(
+pub fn files_match_with<F, G, A>(
     dir: &Path,
     predicate: &F,
-    collect: &mut Vec<String>,
+    collect: &mut Vec<A>,
     map: &G,
 ) -> Result<(), std::io::Error>
 where
     F: Fn(&Path) -> bool,
-    G: Fn(String) -> String,
+    G: Fn(String) -> A,
 {
     for entry in std::fs::read_dir(dir)? {
         let path = entry?.path();

--- a/src/html_flake.rs
+++ b/src/html_flake.rs
@@ -1,6 +1,11 @@
 use std::ops::Not;
 
-use crate::{compiler::taxon::Taxon, config, entry::EntryMetaData, html};
+use crate::{
+    compiler::taxon::Taxon,
+    config,
+    entry::{EntryMetaData, MetaData},
+    html,
+};
 
 pub fn html_article_inner(
     metadata: &EntryMetaData,
@@ -71,12 +76,13 @@ pub fn html_entry_header(mut etc: Vec<String>) -> String {
 pub fn catalog_item(
     slug: &str,
     text: &str,
+    page_title: &str,
     details_open: bool,
     taxon: &str,
     child_html: &str,
 ) -> String {
     let slug_url = config::full_html_url(slug);
-    let title = format!("{} [{}]", text, slug);
+    let title = format!("{} [{}]", page_title, slug);
     let href = format!("#{}", crate::slug::to_hash_id(slug)); // #id
 
     let mut class_name: Vec<String> = vec![];
@@ -124,8 +130,8 @@ pub fn html_link(href: &str, title: &str, text: &str, class_name: &str) -> Strin
       (html!(a href = {href}, title = {title} => {text})))
 }
 
-pub fn html_header_nav(title: &str, href: &str) -> String {
-    let link = html!(a href={href}, title={title} => ("« ") (title));
+pub fn html_header_nav(title: &str, page_title: &str, href: &str) -> String {
+    let link = html!(a href={href}, title={page_title} => ("« ") (title));
     let nav_inner = html!(div class = "logo" => (link));
     html!(header class = "header" => (html!(nav class = "nav" => {nav_inner})))
 }

--- a/src/process/figure.rs
+++ b/src/process/figure.rs
@@ -1,7 +1,7 @@
 use pulldown_cmark::{Tag, TagEnd};
 
 use crate::{
-    compiler::section::LazyContent,
+    compiler::{section::{HTMLContent, LazyContent}, CompileError},
     recorder::{ParseRecorder, State},
 };
 
@@ -40,10 +40,11 @@ impl Processer for Figure {
         &self,
         s: &pulldown_cmark::CowStr<'_>,
         recorder: &mut ParseRecorder,
-        _metadata: &mut std::collections::HashMap<String, String>,
-    ) {
+        _metadata: &mut std::collections::HashMap<String, HTMLContent>,
+    ) -> Result<(), CompileError> {
         if recorder.state == State::Figure {
             recorder.push(s.to_string()); // [1]: alt text
         }
+        Ok(())
     }
 }

--- a/src/process/processer.rs
+++ b/src/process/processer.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{compiler::section::LazyContent, recorder::ParseRecorder};
+use crate::{compiler::{section::{HTMLContent, LazyContent}, CompileError}, recorder::ParseRecorder};
 use pulldown_cmark::{CowStr, Tag, TagEnd};
 
 pub trait Processer {
@@ -17,8 +17,9 @@ pub trait Processer {
         &self,
         s: &CowStr<'_>,
         recorder: &mut ParseRecorder,
-        metadata: &mut HashMap<String, String>,
-    ) {
+        metadata: &mut HashMap<String, HTMLContent>,
+    ) -> Result<(), CompileError> {
+        Ok(())
     }
 
     #[allow(dead_code, unused_variables)]

--- a/src/process/typst_image.rs
+++ b/src/process/typst_image.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use crate::{
-    compiler::section::LazyContent,
+    compiler::{section::{HTMLContent, LazyContent}, CompileError},
     config::{self, join_path, output_path, parent_dir},
     html_flake::{html_figure, html_figure_code},
     recorder::{ParseRecorder, State},
@@ -65,7 +65,7 @@ impl Processer for TypstImage {
                         Err(err) => {
                             eprintln!("{:?} at {}", err, recorder.current);
                             String::new()
-                        },
+                        }
                     };
 
                     recorder.exit();
@@ -202,12 +202,13 @@ impl Processer for TypstImage {
         &self,
         s: &pulldown_cmark::CowStr<'_>,
         recorder: &mut ParseRecorder,
-        _metadata: &mut std::collections::HashMap<String, String>,
-    ) {
+        _metadata: &mut std::collections::HashMap<String, HTMLContent>,
+    )  -> Result<(), CompileError> {
         if allow_inline(&recorder.state) {
             // [1]: imported / inline typst / span / block
-            return recorder.push(s.to_string());
+            recorder.push(s.to_string());
         }
+        Ok(())
     }
 
     fn inline_math(

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -4,15 +4,22 @@ pub fn to_hash_id(slug: &str) -> String {
 
 /// path to slug
 pub fn to_slug(fullname: &str) -> String {
+    to_slug_ext(fullname).0
+}
+
+pub fn to_slug_ext(fullname: &str) -> (String, String) {
     let mut slug = fullname;
     if fullname.starts_with("/") {
         slug = &slug[1..]
     } else if fullname.starts_with("./") {
         slug = &slug[2..]
     }
-
-    let slug = &slug[0..slug.rfind('.').unwrap_or(slug.len())];
-    pretty_path(std::path::Path::new(&slug))
+    let (slug, ext) = if let Some(ix) = slug.rfind('.') {
+        (&slug[0..ix], &slug[(ix+1)..])
+    } else {
+        (slug, "")
+    };
+    (pretty_path(std::path::Path::new(&slug)), ext.to_string())
 }
 
 pub fn pretty_path(path: &std::path::Path) -> String {

--- a/src/typst_cli.rs
+++ b/src/typst_cli.rs
@@ -17,7 +17,7 @@ pub fn source_to_inline_html(typst_path: &str, html_path: &str) -> Result<String
     let full_path = config::join_path(&root_dir, typst_path);
     let html = source_to_html(&full_path, &root_dir)?;
     let html_body = html_to_body_content(&html);
-    
+
     fs::write(html_path, html)?;
     println!(
         "Compiled to HTML: {}",
@@ -90,7 +90,7 @@ pub fn source_to_html(full_path: &str, root_dir: &str) -> Result<String, std::io
         let stderr = String::from_utf8_lossy(&output.stderr);
         eprintln!(
             "Command failed in {} {}: \n  {}",
-            full_path, 
+            full_path,
             concat!(file!(), '#', line!()),
             stderr
         );
@@ -135,11 +135,12 @@ pub fn compile_source(
     })
 }
 
-pub fn source_to_html_inplace(typst_path: &str, root_dir: &str) -> Result<String, std::io::Error> {
-    compile_source_inplace(typst_path, root_dir, "html", Some("--features=html"))
+pub fn file_to_html(typst_path: &str, root_dir: &str) -> Result<String, std::io::Error> {
+    compile_file(typst_path, root_dir, "html", Some("--features=html"))
+        .map(|s| html_to_body_content(&s))
 }
 
-pub fn compile_source_inplace(
+pub fn compile_file(
     typst_path: &str,
     root_dir: &str,
     output_format: &str,
@@ -200,7 +201,7 @@ pub fn write_svg(typst_path: &str, svg_path: &str) -> Result<(), std::io::Error>
         let stderr = String::from_utf8_lossy(&output.stderr);
         eprintln!(
             "Command failed in {} {}: \n  {}",
-            full_path, 
+            full_path,
             concat!(file!(), '#', line!()),
             stderr
         );

--- a/src/typst_cli.rs
+++ b/src/typst_cli.rs
@@ -162,8 +162,9 @@ pub fn compile_file(
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
         eprintln!(
-            "Command failed in {}: \n  {}",
+            "Command failed in {}: \n  In file {}, {}",
             concat!(file!(), '#', line!()),
+            typst_path,
             stderr
         );
         String::new()

--- a/typst/kodama.typ
+++ b/typst/kodama.typ
@@ -1,0 +1,13 @@
+#let meta(key, value) = html.elem("kodama", value, attrs: (type: "meta", key: key))
+#let embed(url, title, numbering: false, open: true, catalog: true) = html.elem(
+  "kodama",
+  title,
+  attrs: (type: "embed", url: url, numbering: repr(numbering), open: repr(open), catalog: repr(catalog)),
+)
+#let local(slug, text) = html.elem("kodama", text, attrs: (type: "local", slug: slug))
+
+#let template(it) = {
+  show: html.elem.with("html")
+
+  it
+}

--- a/typst/kodama.typ
+++ b/typst/kodama.typ
@@ -1,10 +1,40 @@
-#let meta(key, value) = html.elem("kodama", value, attrs: (type: "meta", key: key))
-#let embed(url, title, numbering: false, open: true, catalog: true) = html.elem(
-  "kodama",
-  title,
-  attrs: (type: "embed", url: url, numbering: repr(numbering), open: repr(open), catalog: repr(catalog)),
-)
-#let local(slug, text) = html.elem("kodama", text, attrs: (type: "local", slug: slug))
+#let repri(r) = if type(r) == str {
+  r
+} else {
+  repr(r)
+}
+
+#let meta(key, value) = if type(value) == content {
+  html.elem("kodama", value, attrs: (type: "meta", key: key))
+} else {
+  html.elem("kodama", none, attrs: (type: "meta", key: key, value: repri(value)))
+}
+#let embed(url, title, numbering: false, open: true, catalog: true) = if type(title) == content {
+  html.elem(
+    "kodama",
+    title,
+    attrs: (type: "embed", url: url, numbering: repri(numbering), open: repri(open), catalog: repri(catalog)),
+  )
+} else {
+  html.elem(
+    "kodama",
+    none,
+    attrs: (
+      type: "embed",
+      url: url,
+      numbering: repri(numbering),
+      open: repri(open),
+      catalog: repri(catalog),
+      value: repr(i),
+    ),
+  )
+}
+#let local(slug, text) = if type(text) == content {
+  html.elem("kodama", text, attrs: (type: "local", slug: slug))
+} else {
+  html.elem("kodama", attrs: (type: "local", slug: slug, value: repri(text)))
+}
+#let local-in-meta(slug, text) = "[" + text + "](" + slug + ")"
 
 #let template(it) = {
   show: html.elem.with("html")

--- a/typst/kodama.typ
+++ b/typst/kodama.typ
@@ -4,37 +4,44 @@
   repr(r)
 }
 
-#let meta(key, value) = if type(value) == content {
-  html.elem("kodama", value, attrs: (type: "meta", key: key))
-} else {
-  html.elem("kodama", none, attrs: (type: "meta", key: key, value: repri(value)))
+#let meta(key, value) = {
+  let v = value
+  let attrs = (key: key)
+
+  if type(value) != content {
+    v = none
+    attrs.insert("value", repri(value))
+  }
+
+  html.elem("kodamameta", v, attrs: attrs)
 }
-#let embed(url, title, numbering: false, open: true, catalog: true) = if type(title) == content {
-  html.elem(
-    "kodama",
-    title,
-    attrs: (type: "embed", url: url, numbering: repri(numbering), open: repri(open), catalog: repri(catalog)),
-  )
-} else {
-  html.elem(
-    "kodama",
-    none,
-    attrs: (
-      type: "embed",
-      url: url,
-      numbering: repri(numbering),
-      open: repri(open),
-      catalog: repri(catalog),
-      value: repr(i),
-    ),
-  )
+
+#let embed(url, title, numbering: false, open: true, catalog: true) = {
+  let v = title
+  let attrs = (url: url, numbering: repri(numbering), open: repri(open), catalog: repri(catalog))
+
+  if type(title) != content {
+    v = none
+    attrs.insert("value", repri(title))
+  }
+
+  html.elem("kodamaembed", v, attrs: attrs)
 }
-#let local(slug, text) = if type(text) == content {
-  html.elem("kodama", text, attrs: (type: "local", slug: slug))
-} else {
-  html.elem("kodama", attrs: (type: "local", slug: slug, value: repri(text)))
-}
-#let local-in-meta(slug, text) = "[" + text + "](" + slug + ")"
+
+#let local(slug, text) = html.elem(
+  "span", // Make it an inline element. This is automatically removed by kodama.
+  {
+    let v = text
+    let attrs = (slug: slug)
+
+    if type(text) != content {
+      v = none
+      attrs.insert("value", repri(text))
+    }
+
+    html.elem("kodamalocal", v, attrs: attrs)
+  },
+)
 
 #let template(it) = {
   show: html.elem.with("html")


### PR DESCRIPTION
This pr adds support for typst source file. To distinguish between source file and embedded fragments, it only processes `.typst` files. 

It depends on `<kodama>` tags in the html output, and ships a `kodama.typ` file to illustrate how to achieve that. User should integrate it into their own typst template.