### PR TITLE
Improve the handling of slug extensions and file walking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ pulldown-cmark = { version = "0.12.2", default-features = false, features = ["ht
 regex-lite = "0.1.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+walkdir = "2.5.0"
 
 [profile.release]
 strip = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,11 @@
 use std::{
-    collections::HashMap,
     fs::{self, create_dir_all},
     hash::Hash,
     path::{Path, PathBuf},
     sync::{LazyLock, Mutex},
 };
+
+use walkdir::WalkDir;
 
 #[derive(Clone, clap::ValueEnum)]
 pub enum FooterMode {
@@ -281,51 +282,16 @@ pub fn verify_update_hash(path: &str, content: &str) -> Result<bool, std::io::Er
     Ok(is_modified)
 }
 
-pub fn files_match_with<F, G, H, E, K, V>(
-    dir: &Path,
-    predicate: &F,
-    ignore_dir: &G,
-    collect: &mut HashMap<K, V>,
-    map: &H,
-    error: &E,
-) -> Result<(), std::io::Error>
-where
-    F: Fn(&Path) -> bool,
-    G: Fn(&Path) -> bool,
-    H: Fn(&Path) -> (K, V),
-    E: Fn(&Path, &V) -> std::io::Error,
-    K: Hash + Eq,
-{
-    for entry in std::fs::read_dir(dir)? {
-        let path = entry?.path();
-        if path.is_file() && predicate(&path) {
-            let (a, b) = map(&path);
-            if let Some(b) = collect.insert(a, b) {
-                return Err(error(&path, &b));
-            };
-        } else if path.is_dir() && !ignore_dir(&path) {
-            files_match_with(&path, predicate, ignore_dir, collect, map, error)?;
-        }
-    }
-    Ok(())
-}
-
 #[allow(dead_code)]
 pub fn delete_all_with<F>(dir: &str, predicate: &F) -> Result<(), std::io::Error>
 where
     F: Fn(&Path) -> bool,
 {
-    let mut collect = HashMap::new();
-    files_match_with(
-        Path::new(dir),
-        predicate,
-        &|_| false,
-        &mut collect,
-        &|p| (p.to_owned(), ()),
-        &|_, _| unreachable!(),
-    )?;
-    for (path, _) in collect {
-        std::fs::remove_file(path)?;
+    for entry in WalkDir::new(dir) {
+        let path = entry?.into_path();
+        if path.is_file() && predicate(&path) {
+            std::fs::remove_file(path)?;
+        }
     }
     Ok(())
 }

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -1,3 +1,35 @@
+use std::{fmt::Display, str::FromStr};
+
+#[derive(Debug)]
+pub enum Ext {
+    Markdown,
+    Typst,
+}
+
+pub struct ParseExtensionError;
+
+impl FromStr for Ext {
+    type Err = ParseExtensionError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "md" => Ok(Self::Markdown),
+            "typst" => Ok(Self::Typst),
+            _ => Err(ParseExtensionError),
+        }
+    }
+}
+
+impl Display for Ext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Ext::Markdown => "md",
+            Ext::Typst => "typst",
+        };
+        write!(f, "{s}")
+    }
+}
+
 pub fn to_hash_id(slug: &str) -> String {
     slug.replace("/", "-")
 }
@@ -7,19 +39,17 @@ pub fn to_slug(fullname: &str) -> String {
     to_slug_ext(fullname).0
 }
 
-pub fn to_slug_ext(fullname: &str) -> (String, String) {
+pub fn to_slug_ext(fullname: &str) -> (String, Option<Ext>) {
     let mut slug = fullname;
     if fullname.starts_with("/") {
         slug = &slug[1..]
     } else if fullname.starts_with("./") {
         slug = &slug[2..]
     }
-    let (slug, ext) = if let Some(ix) = slug.rfind('.') {
-        (&slug[0..ix], &slug[(ix+1)..])
-    } else {
-        (slug, "")
-    };
-    (pretty_path(std::path::Path::new(&slug)), ext.to_string())
+    let (maybe_slug, ext) = slug.rsplit_once('.').unzip();
+    let slug = maybe_slug.unwrap_or(slug);
+    let ext = ext.and_then(|e| e.parse().ok());
+    (pretty_path(std::path::Path::new(&slug)), ext)
 }
 
 pub fn pretty_path(path: &std::path::Path) -> String {


### PR DESCRIPTION
This PR:

- Introduces a new dependency `walkdir` to replace `files_match_with`
- Utilizes `Path` methods to handle slugs
- Defines a new type `Ext` to express supported file types

No changes in behavior expected.