### PR TITLE
Introduce error handling with `snafu`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ pulldown-cmark = { version = "0.12.2", default-features = false, features = ["ht
 regex-lite = "0.1.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+snafu = "0.8.5"
 walkdir = "2.5.0"
 
 [profile.release]

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -32,7 +32,7 @@ pub fn initialize(
     std::fs::read_to_string(&markdown_path)
         .map(|markdown_input| (markdown_input, metadata, recorder))
         .context(IOSnafu {
-            file: &markdown_path,
+            path: &markdown_path,
         })
 }
 

--- a/src/compiler/typst.rs
+++ b/src/compiler/typst.rs
@@ -98,7 +98,7 @@ fn parse_typst_html(
 pub fn parse_typst(slug: &str, root_dir: &str) -> Result<ShallowSection, CompileError> {
     let relative_path = format!("{}.typst", slug);
     let html_str = typst_cli::file_to_html(&relative_path, root_dir).context(IOSnafu {
-        file: &relative_path,
+        path: &relative_path,
     })?;
 
     let mut metadata: HashMap<String, HTMLContent> = HashMap::new();

--- a/src/compiler/typst.rs
+++ b/src/compiler/typst.rs
@@ -1,8 +1,11 @@
+use snafu::{OptionExt, ResultExt};
+
 use super::html_parser::{HTMLParser, HTMLTagKind};
 use super::section::{EmbedContent, LocalLink, SectionOption};
 use super::section::{HTMLContent, HTMLContentBuilder, LazyContent};
-use super::{CompileError, ShallowSection};
+use super::ShallowSection;
 use crate::entry::HTMLMetaData;
+use crate::error::{CompileError, IOSnafu, MissingAttrSnafu, SyntaxSnafu};
 use crate::process::embed_markdown;
 use crate::slug::to_slug;
 use crate::typst_cli;
@@ -31,11 +34,12 @@ fn parse_typst_html(
         cursor = span.end;
 
         let attr = |attr_name: &str| {
-            span.attrs.get(attr_name).ok_or(CompileError::Syntax(
-                Some(concat!(file!(), '#', line!())),
-                Box::new(format!("No attribute '{}' in a kodama tag", attr_name)),
-                relative_path.to_string(),
-            ))
+            span.attrs
+                .get(attr_name)
+                .context(MissingAttrSnafu { attr_name })
+                .context(SyntaxSnafu {
+                    file: relative_path,
+                })
         };
 
         let value = || {
@@ -93,12 +97,8 @@ fn parse_typst_html(
 
 pub fn parse_typst(slug: &str, root_dir: &str) -> Result<ShallowSection, CompileError> {
     let relative_path = format!("{}.typst", slug);
-    let html_str = typst_cli::file_to_html(&relative_path, root_dir).map_err(|e| {
-        CompileError::IO(
-            Some(concat!(file!(), '#', line!())),
-            e,
-            relative_path.to_string(),
-        )
+    let html_str = typst_cli::file_to_html(&relative_path, root_dir).context(IOSnafu {
+        file: &relative_path,
     })?;
 
     let mut metadata: HashMap<String, HTMLContent> = HashMap::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,30 @@
+use std::backtrace::Backtrace;
+
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum CompileError {
+    #[snafu(display("failed to operate on file `{file}`"))]
+    IO {
+        file: String,
+        source: std::io::Error,
+        backtrace: Option<Backtrace>,
+    },
+    #[snafu(display("failed to parse file `{file}`"))]
+    Syntax {
+        file: String,
+        #[snafu(backtrace)]
+        source: SyntaxError,
+    },
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub(crate)))]
+pub enum SyntaxError {
+    #[snafu(display("no attribute `{attr_name}` in a kodama tag"))]
+    MissingAttr {
+        attr_name: String,
+        backtrace: Option<Backtrace>,
+    },
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,22 @@
-use std::backtrace::Backtrace;
+use std::{backtrace::Backtrace, path::PathBuf};
 
 use snafu::Snafu;
+
+use crate::slug::Ext;
 
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum CompileError {
-    #[snafu(display("failed to operate on file `{file}`"))]
+    #[snafu(display("failed to operate on file `{}`", path.display()))]
     IO {
-        file: String,
+        path: PathBuf,
         source: std::io::Error,
+        backtrace: Option<Backtrace>,
+    },
+    #[snafu(display("`{}` collides with `{}`", path.display(), path.with_extension(ext.to_string()).display()))]
+    FileCollison {
+        path: PathBuf,
+        ext: Ext,
         backtrace: Option<Backtrace>,
     },
     #[snafu(display("failed to parse file `{file}`"))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,12 @@ pub enum CompileError {
         ext: Ext,
         backtrace: Option<Backtrace>,
     },
+    #[snafu(display("failed to deserialize entry `{}`", path.display()))]
+    DeserializeEntry {
+        path: PathBuf,
+        source: serde_json::Error,
+        backtrace: Option<Backtrace>,
+    },
     #[snafu(display("failed to parse file `{file}`"))]
     Syntax {
         file: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod compiler;
 mod config;
 mod entry;
+mod error;
 mod html_flake;
 mod html_macro;
 mod process;
@@ -112,9 +113,8 @@ fn main() {
                 export_css_files()
             }
 
-            match compiler::compile_all(root) {
-                Err(err) => eprintln!("{:?}", err),
-                Ok(_) => (),
+            if let Err(e) = compiler::compile_all(root) {
+                report_error(e);
             }
         }
         Command::Clean(clean_command) => {
@@ -173,5 +173,14 @@ fn export_css_file(css_content: &str, name: &str) {
             Err(err) => eprintln!("{:?}", err),
             Ok(_) => (),
         }
+    }
+}
+
+fn report_error<E: snafu::Error + snafu::ErrorCompat>(e: E) {
+    eprint!("{}", snafu::Report::from_error(&e));
+    if let Some(trace) = snafu::ErrorCompat::backtrace(&e) {
+        eprintln!("backtrace:\n{trace}");
+    } else {
+        eprintln!("note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod recorder;
 mod slug;
 mod typst_cli;
 
-use std::fs;
+use std::{fs, path::Path};
 
 use clap::Parser;
 use config::{output_path, CompileConfig, FooterMode};
@@ -131,30 +131,25 @@ fn main() {
                 ),
             );
 
-            let cache_dir = &config::get_cache_dir();
+            let cache_dir = config::get_cache_dir();
+
+            let path_ends_with =
+                |suffix: &'static str| move |p: &Path| p.to_string_lossy().ends_with(suffix);
 
             clean_command.markdown.then(|| {
-                let _ = config::delete_all_with(&cache_dir, &|s| {
-                    s.to_str().unwrap().ends_with(".md.hash")
-                });
+                let _ = config::delete_all_with(&cache_dir, &path_ends_with(".md.hash"));
             });
 
             clean_command.typ.then(|| {
-                let _ = config::delete_all_with(&cache_dir, &|s| {
-                    s.to_str().unwrap().ends_with(".typ.hash")
-                });
+                let _ = config::delete_all_with(&cache_dir, &path_ends_with(".typ.hash"));
             });
 
             clean_command.typst.then(|| {
-                let _ = config::delete_all_with(&cache_dir, &|s| {
-                    s.to_str().unwrap().ends_with(".typst.hash")
-                });
+                let _ = config::delete_all_with(&cache_dir, &path_ends_with(".typst.hash"));
             });
 
             clean_command.html.then(|| {
-                let _ = config::delete_all_with(&cache_dir, &|s| {
-                    s.to_str().unwrap().ends_with(".html.hash")
-                });
+                let _ = config::delete_all_with(&cache_dir, &path_ends_with(".html.hash"));
             });
         }
     }

--- a/src/process/embed_markdown.rs
+++ b/src/process/embed_markdown.rs
@@ -5,8 +5,8 @@ use crate::{
     compiler::{
         parser::parse_spanned_markdown,
         section::{EmbedContent, HTMLContent, LazyContent, LocalLink, SectionOption},
-        CompileError,
     },
+    error::CompileError,
     html_flake::html_link,
     recorder::{ParseRecorder, State},
     slug::to_slug,

--- a/src/process/figure.rs
+++ b/src/process/figure.rs
@@ -1,7 +1,8 @@
 use pulldown_cmark::{Tag, TagEnd};
 
 use crate::{
-    compiler::{section::{HTMLContent, LazyContent}, CompileError},
+    compiler::section::{HTMLContent, LazyContent},
+    error::CompileError,
     recorder::{ParseRecorder, State},
 };
 

--- a/src/process/processer.rs
+++ b/src/process/processer.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
 
-use crate::{compiler::{section::{HTMLContent, LazyContent}, CompileError}, recorder::ParseRecorder};
+use crate::{
+    compiler::section::{HTMLContent, LazyContent},
+    error::CompileError,
+    recorder::ParseRecorder,
+};
 use pulldown_cmark::{CowStr, Tag, TagEnd};
 
 pub trait Processer {

--- a/src/process/typst_image.rs
+++ b/src/process/typst_image.rs
@@ -1,8 +1,9 @@
 use std::fs;
 
 use crate::{
-    compiler::{section::{HTMLContent, LazyContent}, CompileError},
+    compiler::section::{HTMLContent, LazyContent},
     config::{self, join_path, output_path, parent_dir},
+    error::CompileError,
     html_flake::{html_figure, html_figure_code},
     recorder::{ParseRecorder, State},
     slug::adjust_name,
@@ -203,7 +204,7 @@ impl Processer for TypstImage {
         s: &pulldown_cmark::CowStr<'_>,
         recorder: &mut ParseRecorder,
         _metadata: &mut std::collections::HashMap<String, HTMLContent>,
-    )  -> Result<(), CompileError> {
+    ) -> Result<(), CompileError> {
         if allow_inline(&recorder.state) {
             // [1]: imported / inline typst / span / block
             recorder.push(s.to_string());


### PR DESCRIPTION
This PR introduces `snafu` to better handle errors. The old `CompileError` is reorganized and a few `unwrap`s are replaced with proper error types, improving error reports and reducing panics.