### PR TITLE
Rework `CompileState`

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -13,7 +13,6 @@ use std::{collections::HashMap, fs::File, io::BufReader, path::Path};
 use eyre::{bail, eyre, WrapErr};
 use parser::parse_markdown;
 use section::{HTMLContent, ShallowSection};
-use state::CompileState;
 use typst::parse_typst;
 use walkdir::WalkDir;
 use writer::Writer;
@@ -24,8 +23,8 @@ use crate::{
 };
 
 pub fn compile_all(workspace_dir: &str) -> eyre::Result<()> {
-    let mut state = CompileState::new();
     let workspace = all_source_files(Path::new(workspace_dir))?;
+    let mut shallows = HashMap::new();
 
     for (slug, ext) in &workspace.slug_exts {
         let relative_path = format!("{}.{}", slug, ext);
@@ -66,10 +65,10 @@ pub fn compile_all(workspace_dir: &str) -> eyre::Result<()> {
             shallow
         };
 
-        state.residued.insert(slug.to_string(), shallow);
+        shallows.insert(slug.to_string(), shallow);
     }
 
-    state.compile_all();
+    let state = state::compile_all(shallows);
 
     Writer::write_needed_slugs(
         &workspace.slug_exts.into_iter().map(|x| x.0).collect(),

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -68,7 +68,7 @@ pub fn compile_all(workspace_dir: &str) -> eyre::Result<()> {
         shallows.insert(slug.to_string(), shallow);
     }
 
-    let state = state::compile_all(shallows);
+    let state = state::compile_all(shallows)?;
 
     Writer::write_needed_slugs(
         &workspace.slug_exts.into_iter().map(|x| x.0).collect(),

--- a/src/compiler/state.rs
+++ b/src/compiler/state.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 
 use crate::{
     config,
@@ -14,60 +14,57 @@ use super::{
 
 #[derive(Debug)]
 pub struct CompileState {
-    pub residued: HashMap<String, ShallowSection>,
-    pub compiled: HashMap<String, Section>,
-    pub metadata: HashMap<String, HTMLMetaData>,
-    pub callback: Callback,
+    residued: BTreeSet<String>,
+    compiled: HashMap<String, Section>,
+    callback: Callback,
+}
+
+type Shallows = HashMap<String, ShallowSection>;
+
+pub fn compile_all(mut shallows: Shallows) -> CompileState {
+    for shallow in shallows.values_mut() {
+        shallow.metadata.compute_textual_attrs();
+    }
+
+    let residued: BTreeSet<String> = shallows.keys().cloned().collect();
+
+    let mut state = CompileState::new(residued);
+    state.compile(&shallows, "index");
+
+    /*
+     * Unlinked or unembedded pages.
+     */
+    while let Some(slug) = state.residued.pop_first() {
+        state.compile(&shallows, &slug);
+    }
+
+    state
 }
 
 impl CompileState {
-    pub fn new() -> CompileState {
+    fn new(residued: BTreeSet<String>) -> CompileState {
         CompileState {
-            residued: HashMap::new(),
+            residued,
             compiled: HashMap::new(),
-            metadata: HashMap::new(),
             callback: Callback::new(),
         }
     }
 
-    fn compile(&mut self, slug: &str) -> &Section {
-        self.fetch_section(slug).unwrap()
+    fn compile(&mut self, shallows: &Shallows, slug: &str) -> &Section {
+        self.fetch_section(shallows, slug).unwrap()
     }
 
-    pub fn compile_all(&mut self) {
-        self.metadata = self
-            .residued
-            .iter_mut()
-            .map(|(key, value)| {
-                value.metadata.compute_textual_attrs();
-                (key.to_string(), value.metadata.clone())
-            })
-            .collect();
-
-        self.compile("index");
-        /*
-         * Unlinked or unembedded pages.
-         */
-        let residued_slugs: Vec<String> = self.residued.keys().map(|s| s.to_string()).collect();
-        for slug in residued_slugs {
-            self.compile(&slug);
-        }
-    }
-
-    fn fetch_section(&mut self, slug: &str) -> Option<&Section> {
+    fn fetch_section(&mut self, shallows: &Shallows, slug: &str) -> Option<&Section> {
         if self.compiled.contains_key(slug) {
-            return Some(self.compiled.get(slug).unwrap());
+            Some(self.compiled.get(slug).unwrap())
+        } else {
+            shallows
+                .get(slug)
+                .map(|shallow| self.compile_shallow(shallows, shallow))
         }
-
-        if self.residued.contains_key(slug) {
-            let shallow = self.residued.remove(slug).unwrap();
-            return Some(self.compile_shallow(shallow));
-        }
-
-        None // unreachable!("CompileState::fetch_section")
     }
 
-    fn compile_shallow(&mut self, shallow: ShallowSection) -> &Section {
+    fn compile_shallow(&mut self, shallows: &Shallows, shallow: &ShallowSection) -> &Section {
         let slug = shallow.slug();
         let mut children: SectionContents = vec![];
         let mut references: HashSet<String> = HashSet::new();
@@ -86,7 +83,7 @@ impl CompileState {
                         }
                         LazyContent::Embed(embed_content) => {
                             let child_slug = slug::to_slug(&embed_content.url);
-                            let refered = match self.fetch_section(&child_slug) {
+                            let refered = match self.fetch_section(shallows, &child_slug) {
                                 Some(refered_section) => refered_section,
                                 None => {
                                     eprintln!(
@@ -113,11 +110,10 @@ impl CompileState {
                         }
                         LazyContent::Local(local_link) => {
                             let link_slug = &local_link.slug;
-                            let article_title = self
-                                .get_metadata(&link_slug)
+                            let article_title = get_metadata(shallows, link_slug)
                                 .map_or("", |s| s.page_title().map_or("", |s| s));
 
-                            if self.is_reference(&link_slug) {
+                            if is_reference(shallows, link_slug) {
                                 references.insert(link_slug.to_string());
                             }
 
@@ -126,7 +122,7 @@ impl CompileState {
                              */
                             if *link_slug != slug
                                 && format!("{}:metadata", link_slug) != slug
-                                && self.is_enable_backlinks(&link_slug)
+                                && is_enable_backlinks(shallows, link_slug)
                             {
                                 callback.insert_backlinks(
                                     link_slug.to_string(),
@@ -161,7 +157,7 @@ impl CompileState {
             }
             let value = shallow.metadata.get(key).unwrap();
             let spanned: ShallowSection = Self::metadata_to_section(value, &slug);
-            let compiled = self.compile_shallow(spanned);
+            let compiled = self.compile_shallow(shallows, &spanned);
             let html = compiled.spanned();
             metadata.update(key.to_string(), html);
         });
@@ -181,27 +177,39 @@ impl CompileState {
             HTMLContent::Plain(format!("{}:metadata", current_slug)),
         );
 
-        return ShallowSection {
+        ShallowSection {
             metadata: HTMLMetaData(metadata),
             content: content.clone(),
-        };
+        }
     }
 
-    fn get_metadata(&self, slug: &str) -> Option<&HTMLMetaData> {
-        self.metadata.get(slug)
+    pub fn compiled(&self) -> &HashMap<String, Section> {
+        &self.compiled
     }
 
-    fn is_enable_backlinks(&self, slug: &str) -> bool {
-        self.metadata
-            .get(slug)
-            .map(|e| e.is_enable_backlinks())
-            .unwrap_or(true)
+    pub fn callback(&self) -> &Callback {
+        &self.callback
     }
+}
 
-    fn is_reference(&self, slug: &str) -> bool {
-        self.metadata
-            .get(slug)
-            .map(|e| e.is_asref() || Taxon::is_reference(e.data_taxon().map_or("", String::as_str)))
-            .unwrap_or(false)
-    }
+fn get_metadata<'s>(shallows: &'s Shallows, slug: &str) -> Option<&'s HTMLMetaData> {
+    shallows.get(slug).map(|s| &s.metadata)
+}
+
+fn is_enable_backlinks(shallows: &Shallows, slug: &str) -> bool {
+    shallows
+        .get(slug)
+        .map(|s| s.metadata.is_enable_backlinks())
+        .unwrap_or(true)
+}
+
+fn is_reference(shallows: &Shallows, slug: &str) -> bool {
+    shallows
+        .get(slug)
+        .map(|s| {
+            let metadata = &s.metadata;
+            metadata.is_asref()
+                || Taxon::is_reference(metadata.data_taxon().map_or("", String::as_str))
+        })
+        .unwrap_or(false)
 }

--- a/src/compiler/state.rs
+++ b/src/compiler/state.rs
@@ -30,7 +30,7 @@ impl CompileState {
         }
     }
 
-    pub fn compile(&mut self, slug: &str) -> &Section {
+    fn compile(&mut self, slug: &str) -> &Section {
         self.fetch_section(slug).unwrap()
     }
 
@@ -174,7 +174,7 @@ impl CompileState {
         self.compiled.get(&slug).unwrap()
     }
 
-    pub fn metadata_to_section(content: &HTMLContent, current_slug: &str) -> ShallowSection {
+    fn metadata_to_section(content: &HTMLContent, current_slug: &str) -> ShallowSection {
         let mut metadata = HashMap::new();
         metadata.insert(
             KEY_SLUG.to_string(),
@@ -187,18 +187,18 @@ impl CompileState {
         };
     }
 
-    pub fn get_metadata(&self, slug: &str) -> Option<&HTMLMetaData> {
+    fn get_metadata(&self, slug: &str) -> Option<&HTMLMetaData> {
         self.metadata.get(slug)
     }
 
-    pub fn is_enable_backlinks(&self, slug: &str) -> bool {
+    fn is_enable_backlinks(&self, slug: &str) -> bool {
         self.metadata
             .get(slug)
             .map(|e| e.is_enable_backlinks())
             .unwrap_or(true)
     }
 
-    pub fn is_reference(&self, slug: &str) -> bool {
+    fn is_reference(&self, slug: &str) -> bool {
         self.metadata
             .get(slug)
             .map(|e| e.is_asref() || Taxon::is_reference(e.data_taxon().map_or("", String::as_str)))

--- a/src/compiler/writer.rs
+++ b/src/compiler/writer.rs
@@ -38,7 +38,7 @@ impl Writer {
     pub fn write_needed_slugs(all_slugs: &Vec<String>, state: &CompileState) {
         all_slugs
             .iter()
-            .for_each(|slug| match state.compiled.get(slug) {
+            .for_each(|slug| match state.compiled().get(slug) {
                 /*
                  * No need for `state.compiled.remove(slug)` here,
                  * because writing to a file does not require a mutable reference
@@ -62,7 +62,7 @@ impl Writer {
         let slug = section.slug();
         let html_header = Writer::header(state, &slug);
 
-        let callback = state.callback.0.get(&slug);
+        let callback = state.callback().0.get(&slug);
         let footer_html = Writer::footer(state, &section.references, callback);
         let page_title = section.metadata.page_title().map_or("", |s| s.as_str());
 
@@ -79,12 +79,12 @@ impl Writer {
 
     fn header(state: &CompileState, slug: &str) -> String {
         state
-            .callback
+            .callback()
             .0
             .get(slug)
             .and_then(|callback| {
                 let parent = &callback.parent;
-                state.compiled.get(parent).map(|section| {
+                state.compiled().get(parent).map(|section| {
                     let href = config::full_html_url(parent);
                     let title = section.metadata.title().map_or("", |s| s);
                     let page_title = section.metadata.page_title().map_or("", |s| s);
@@ -106,7 +106,7 @@ impl Writer {
             .iter()
             .map(|slug| {
                 let slug = slug.to_string();
-                let section = state.compiled.get(&slug).unwrap();
+                let section = state.compiled().get(&slug).unwrap();
                 Writer::footer_section_to_html(section)
             })
             .reduce(|s, t| s + &t)
@@ -121,7 +121,7 @@ impl Writer {
                     .iter()
                     .map(|slug| {
                         let slug = Writer::clip_metadata_badge(slug);
-                        let section = state.compiled.get(&slug).unwrap();
+                        let section = state.compiled().get(&slug).unwrap();
                         Writer::footer_section_to_html(section)
                     })
                     .reduce(|s, t| s + &t)


### PR DESCRIPTION
- Split shallow sections and residued to avoid extra clones and accidental mutations
- Removed `CompileState.metadata` for the same reason
- Pass shallow sections as a parameter (since it's read-only)
- Removed unnecessary public items and replaced read-only external accesses with getters
- A nice error message for missing index