### PR TITLE
Rework the `html!` macro

### DIFF
--- a/src/compiler/writer.rs
+++ b/src/compiler/writer.rs
@@ -130,7 +130,7 @@ impl Writer {
             })
             .unwrap_or_default();
 
-        html!(footer => { (references_html) (backlinks_html) })
+        html!(footer { (references_html) (backlinks_html) })
     }
 
     fn clip_metadata_badge(slug: &str) -> String {
@@ -141,8 +141,8 @@ impl Writer {
     }
 
     fn catalog_block(items: &str) -> String {
-        html!(div class = "block" => {
-          h1 => { "Table of Contents" }
+        html!(div class="block" {
+          h1 { "Table of Contents" }
           (items)
         })
     }

--- a/src/compiler/writer.rs
+++ b/src/compiler/writer.rs
@@ -4,8 +4,8 @@ use crate::{
     compiler::counter::Counter,
     config::{self, verify_update_hash},
     entry::MetaData,
-    html,
     html_flake::{self, html_article_inner},
+    html_macro::html,
 };
 
 use super::{
@@ -130,7 +130,7 @@ impl Writer {
             })
             .unwrap_or_default();
 
-        html!(footer => (references_html) (backlinks_html))
+        html!(footer => { (references_html) (backlinks_html) })
     }
 
     fn clip_metadata_badge(slug: &str) -> String {
@@ -141,8 +141,10 @@ impl Writer {
     }
 
     fn catalog_block(items: &str) -> String {
-        html!(div class = "block" =>
-          (html!(h1 => "Table of Contents")) (items))
+        html!(div class = "block" => {
+          h1 => { "Table of Contents" }
+          (items)
+        })
     }
 
     fn catalog_item(section: &Section, taxon: &str, child_html: &str) -> String {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -181,11 +181,11 @@ impl EntryMetaData {
         let slug_url = config::full_html_url(&slug);
         let span_class: Vec<String> = vec!["taxon".to_string()];
 
-        html!(header => {
-            h1 => {
-                span class = {span_class.join(" ")} => { (taxon) }
+        html!(header {
+            h1 {
+                span class={span_class.join(" ")} { (taxon) }
                 (title) " "
-                a class = "slug", href = {slug_url} => { "["(slug_text)"]" }
+                a class="slug" href={slug_url} { "["(slug_text)"]" }
             }
             (html_entry_header(self.etc()))
         })

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,7 +1,8 @@
 use crate::{
     compiler::{section::HTMLContent, taxon::Taxon},
-    config, html,
+    config,
     html_flake::html_entry_header,
+    html_macro::html,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{hash_map::Keys, HashMap};
@@ -180,12 +181,14 @@ impl EntryMetaData {
         let slug_url = config::full_html_url(&slug);
         let span_class: Vec<String> = vec!["taxon".to_string()];
 
-        html!(header =>
-          (html!(h1 =>
-            (html!(span class = {span_class.join(" ")} => {taxon}))
-            {title} {" "}
-            (html!(a class = "slug", href = {slug_url} => "["{&slug_text}"]"))))
-          (html!(html_entry_header(self.etc()))))
+        html!(header => {
+            h1 => {
+                span class = {span_class.join(" ")} => { (taxon) }
+                (title) " "
+                a class = "slug", href = {slug_url} => { "["(slug_text)"]" }
+            }
+            (html_entry_header(self.etc()))
+        })
     }
 
     /// hidden suffix `/index` in slug text.

--- a/src/html_flake.rs
+++ b/src/html_flake.rs
@@ -29,9 +29,9 @@ pub fn html_article_inner(
 
 pub fn html_footer_section(summary: &str, content: &String) -> String {
     let summary = format!("<header><h1>{}</h1></header>", summary);
-    let inner_html = format!("{}{}", (html!(summary => { (summary) })), content);
+    let inner_html = format!("{}{}", (html!(summary { (summary) })), content);
     let html_details = format!("<details open>{}</details>", inner_html);
-    html!(section class="block" => { (html_details) })
+    html!(section class="block" { (html_details) })
 }
 
 pub fn html_section(
@@ -48,9 +48,9 @@ pub fn html_section(
     }
     let data_taxon = data_taxon.map_or("", |s| s);
     let open = open.then(|| "open").unwrap_or("");
-    let inner_html = format!("{}{}", (html!(summary id={id} => { (summary) })), content);
+    let inner_html = format!("{}{}", (html!(summary id={id} { (summary) })), content);
     let html_details = format!("<details {}>{}</details>", open, inner_html);
-    html!(section class={class_name.join(" ")}, data_taxon={data_taxon} => { (html_details) })
+    html!(section class={class_name.join(" ")} data_taxon={data_taxon} { (html_details) })
 }
 
 pub fn html_entry_header(mut etc: Vec<String>) -> String {
@@ -59,11 +59,11 @@ pub fn html_entry_header(mut etc: Vec<String>) -> String {
 
     let items = meta_items
         .iter()
-        .map(|item| html!(li class = "meta-item" => { (item) }))
+        .map(|item| html!(li class="meta-item" { (item) }))
         .reduce(|s: String, t: String| s + t.as_str())
         .unwrap_or(String::new());
 
-    html!(div class="metadata" => { ul => { (items) } })
+    html!(div class="metadata" { ul { (items) } })
 }
 
 pub fn catalog_item(
@@ -83,10 +83,10 @@ pub fn catalog_item(
         class_name.push("item-summary".to_string());
     }
 
-    html!(li class = {class_name.join(" ")} => {
-        a class = "bullet", href={slug_url}, title={title_text} => { "■" }
-        span class = "link local", onclick = {onclick} => {
-            span class = "taxon" => { (taxon) }
+    html!(li class={class_name.join(" ")} {
+        a class="bullet" href={slug_url} title={title_text} { "■" }
+        span class="link local" onclick={onclick} {
+            span class="taxon" { (taxon) }
             (title)
         }
         (child_html)
@@ -103,32 +103,38 @@ pub fn html_figure(image_src: &str, center: bool, caption: String) -> String {
     }
     let mut caption = caption;
     if !caption.is_empty() {
-        caption = html!(figcaption => { (caption) })
+        caption = html!(figcaption { (caption) })
     }
-    html!(figure => { (html_image(image_src)) (caption) })
+    html!(figure { (html_image(image_src)) (caption) })
 }
 
 pub fn html_figure_code(image_src: &str, caption: String, code: String) -> String {
     let mut caption = caption;
     if !caption.is_empty() {
-        caption = html!(figcaption => { (caption) })
+        caption = html!(figcaption { (caption) })
     }
-    let figure = html!(figure => { (html_image(image_src)) (caption) });
-    let pre = html!(pre => { (code) });
-    html!(details => { summary => { (figure) } (pre) })
+    let figure = html!(figure { (html_image(image_src)) (caption) });
+    let pre = html!(pre { (code) });
+    html!(details { summary { (figure) } (pre) })
 }
 
 pub fn html_link(href: &str, title: &str, text: &str, class_name: &str) -> String {
-    html!(span class = format!("link {}", class_name) => {
-        a href = {href}, title = {title} => { (text) }
+    html!(span class={format!("link {}", class_name)} {
+        a href={href} title={title} { (text) }
     })
 }
 
 pub fn html_header_nav(title: &str, page_title: &str, href: &str) -> String {
     let onclick = format!("window.location.href='{}'", href);
-    let link = html!(span onclick={onclick}, title={page_title} => { "« " (title) });
-    let nav_inner = html!(div class = "logo" => { (link) });
-    html!(header class = "header" => { nav class = "nav" => { (nav_inner) } })
+    html!(header class="header" {
+        nav class="nav" {
+            div class="logo" {
+                span onclick={onclick} title={page_title} {
+                    "« " (title)
+                }
+            }
+        }
+    })
 }
 
 pub fn html_doc(
@@ -142,34 +148,34 @@ pub fn html_doc(
     let toc_html = catalog_html
         .is_empty()
         .not()
-        .then(|| html!(nav id = "toc" => { (catalog_html) }))
+        .then(|| html!(nav id="toc" { (catalog_html) }))
         .unwrap_or_default();
 
-    let body_inner = html!(div id="grid-wrapper" => {
-      article => { (article_inner) (footer_html) }
+    let body_inner = html!(div id="grid-wrapper" {
+      article { (article_inner) (footer_html) }
       "\n\n"
       (toc_html)
     });
 
-    let html = html!(html lang = "en-US" => {
-        head => {
+    let html = html!(html lang="en-US" {
+        head {
             r#"
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width">"#
-            (format!("<title>{page_title}</title>")) 
+            (format!("<title>{page_title}</title>"))
             (html_import_meta())
             (html_css())
             (html_import_fonts())
             (html_import_math())
         }
-        body => { (header_html) (body_inner) }
+        body { (header_html) (body_inner) }
     });
     format!("{}\n{}", doc_type, html)
 }
 
 pub fn html_css() -> String {
     match config::disable_export_css() {
-        true => html!(style => { (html_main_style()) (html_typst_style()) }),
+        true => html!(style { (html_main_style()) (html_typst_style()) }),
         false => {
             let base_url = config::base_url();
             format!(

--- a/src/html_flake.rs
+++ b/src/html_flake.rs
@@ -3,7 +3,7 @@ use std::ops::Not;
 use crate::{
     config,
     entry::{EntryMetaData, MetaData},
-    html,
+    html_macro::html,
 };
 
 pub fn html_article_inner(
@@ -29,9 +29,9 @@ pub fn html_article_inner(
 
 pub fn html_footer_section(summary: &str, content: &String) -> String {
     let summary = format!("<header><h1>{}</h1></header>", summary);
-    let inner_html = format!("{}{}", (html!(summary => {summary})), content);
+    let inner_html = format!("{}{}", (html!(summary => { (summary) })), content);
     let html_details = format!("<details open>{}</details>", inner_html);
-    html!(section class="block" => {html_details})
+    html!(section class="block" => { (html_details) })
 }
 
 pub fn html_section(
@@ -48,9 +48,9 @@ pub fn html_section(
     }
     let data_taxon = data_taxon.map_or("", |s| s);
     let open = open.then(|| "open").unwrap_or("");
-    let inner_html = format!("{}{}", (html!(summary id={id} => {summary})), content);
+    let inner_html = format!("{}{}", (html!(summary id={id} => { (summary) })), content);
     let html_details = format!("<details {}>{}</details>", open, inner_html);
-    html!(section class = {class_name.join(" ")}, data_taxon = {data_taxon} => {html_details})
+    html!(section class={class_name.join(" ")}, data_taxon={data_taxon} => { (html_details) })
 }
 
 pub fn html_entry_header(mut etc: Vec<String>) -> String {
@@ -59,11 +59,11 @@ pub fn html_entry_header(mut etc: Vec<String>) -> String {
 
     let items = meta_items
         .iter()
-        .map(|item| html!(li class = "meta-item" => {item}))
-        .reduce(|s, t| s + &t)
+        .map(|item| html!(li class = "meta-item" => { (item) }))
+        .reduce(|s: String, t: String| s + t.as_str())
         .unwrap_or(String::new());
 
-    html!(div class="metadata" => (html!(ul => {items})))
+    html!(div class="metadata" => { ul => { (items) } })
 }
 
 pub fn catalog_item(
@@ -83,12 +83,14 @@ pub fn catalog_item(
         class_name.push("item-summary".to_string());
     }
 
-    html!(li class = {class_name.join(" ")} =>
-      (html!(a class = "bullet", href={slug_url}, title={title_text} => "■"))
-      (html!(span class = "link local", onclick = {onclick} =>
-          (html!(span class = "taxon" => {taxon}))
-          (title)))
-      (child_html))
+    html!(li class = {class_name.join(" ")} => {
+        a class = "bullet", href={slug_url}, title={title_text} => { "■" }
+        span class = "link local", onclick = {onclick} => {
+            span class = "taxon" => { (taxon) }
+            (title)
+        }
+        (child_html)
+    })
 }
 
 pub fn html_image(image_src: &str) -> String {
@@ -101,32 +103,32 @@ pub fn html_figure(image_src: &str, center: bool, caption: String) -> String {
     }
     let mut caption = caption;
     if !caption.is_empty() {
-        caption = html!(figcaption => (caption))
+        caption = html!(figcaption => { (caption) })
     }
-    html!(figure => (html_image(image_src)) (caption))
+    html!(figure => { (html_image(image_src)) (caption) })
 }
 
 pub fn html_figure_code(image_src: &str, caption: String, code: String) -> String {
     let mut caption = caption;
     if !caption.is_empty() {
-        caption = html!(figcaption => (caption))
+        caption = html!(figcaption => { (caption) })
     }
-    let figure = html!(figure => (html_image(image_src)) (caption));
-    let pre = html!(pre => (code));
-    let details = html!(details => (html!(summary => (figure))) (pre));
-    details
+    let figure = html!(figure => { (html_image(image_src)) (caption) });
+    let pre = html!(pre => { (code) });
+    html!(details => { summary => { (figure) } (pre) })
 }
 
 pub fn html_link(href: &str, title: &str, text: &str, class_name: &str) -> String {
-    html!(span class = format!("link {}", class_name) => 
-      (html!(a href = {href}, title = {title} => {text})))
+    html!(span class = format!("link {}", class_name) => {
+        a href = {href}, title = {title} => { (text) }
+    })
 }
 
 pub fn html_header_nav(title: &str, page_title: &str, href: &str) -> String {
     let onclick = format!("window.location.href='{}'", href);
-    let link = html!(span onclick={onclick}, title={page_title} => ("« ") (title));
-    let nav_inner = html!(div class = "logo" => (link));
-    html!(header class = "header" => (html!(nav class = "nav" => {nav_inner})))
+    let link = html!(span onclick={onclick}, title={page_title} => { "« " (title) });
+    let nav_inner = html!(div class = "logo" => { (link) });
+    html!(header class = "header" => { nav class = "nav" => { (nav_inner) } })
 }
 
 pub fn html_doc(
@@ -140,30 +142,34 @@ pub fn html_doc(
     let toc_html = catalog_html
         .is_empty()
         .not()
-        .then(|| html!(nav id = "toc" => {catalog_html}))
+        .then(|| html!(nav id = "toc" => { (catalog_html) }))
         .unwrap_or_default();
 
-    let body_inner = html!(div id="grid-wrapper" => 
-      (html!(article => (article_inner) (footer_html)))
+    let body_inner = html!(div id="grid-wrapper" => {
+      article => { (article_inner) (footer_html) }
       "\n\n"
-      (toc_html));
+      (toc_html)
+    });
 
-    let html = html!(html lang = "en-US" => 
-      (html!(head => r#"
+    let html = html!(html lang = "en-US" => {
+        head => {
+            r#"
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <meta name="viewport" content="width=device-width">"#
-        (format!("<title>{page_title}</title>")) 
-        (html_import_meta())
-        (html_css())
-        (html_import_fonts())
-        (html_import_math()) ))
-      (html!(body => (header_html) (body_inner))));
-    format!("{}\n{}", doc_type, &html)
+            (format!("<title>{page_title}</title>")) 
+            (html_import_meta())
+            (html_css())
+            (html_import_fonts())
+            (html_import_math())
+        }
+        body => { (header_html) (body_inner) }
+    });
+    format!("{}\n{}", doc_type, html)
 }
 
 pub fn html_css() -> String {
     match config::disable_export_css() {
-        true => html!(style => (html_main_style()) (html_typst_style())),
+        true => html!(style => { (html_main_style()) (html_typst_style()) }),
         false => {
             let base_url = config::base_url();
             format!(

--- a/src/html_macro.rs
+++ b/src/html_macro.rs
@@ -6,7 +6,7 @@
 /// ```
 macro_rules! html_write {
     // Match a single HTML element with attributes and children
-    ($str:expr; $tag:ident $($attr:ident = $val:expr),* => { $($inner:tt)* } $($rest:tt)*) => {
+    ($str:expr; $tag:ident $($attr:ident = $val:tt)* { $($inner:tt)* } $($rest:tt)*) => {
         write!($str, "<{}", stringify!($tag)).unwrap();
 
         // Add attributes
@@ -49,8 +49,9 @@ macro_rules! html_write {
 /// Example:
 /// ```rust
 /// let value = 1;
+/// let id = "some_id";
 /// let html = html!(
-///     p class="c",id="id" => { (value) }
+///     p class="c" id=(id.to_string()) { (value) }
 ///     br
 ///     "abc"
 /// );

--- a/src/html_macro.rs
+++ b/src/html_macro.rs
@@ -1,35 +1,69 @@
+/// Example:
+/// ```rust
+/// let mut s = "a";
+/// let html = html_write!(&mut s; br);
+/// assert_eq!(html, r#"a<br />"#)
+/// ```
+macro_rules! html_write {
+    // Match a single HTML element with attributes and children
+    ($str:expr; $tag:ident $($attr:ident = $val:expr),* => { $($inner:tt)* } $($rest:tt)*) => {
+        write!($str, "<{}", stringify!($tag)).unwrap();
 
-#[macro_export]
-macro_rules! html {
-  // Match a single HTML element with attributes and children
-  ($tag:ident $($attr:ident = $val:expr),* => $($inner:tt)*) => {{
-      let mut html = String::new();
-      html.push_str(&format!("<{}", stringify!($tag)));
+        // Add attributes
+        $(
+            write!($str, " {}=\"{}\"", stringify!($attr).replace("_", "-"), $val).unwrap();
+        )*
 
-      // Add attributes
-      $(
-          html.push_str(&format!(" {}=\"{}\"",
-            (stringify!($attr)).replace("_", "-"), $val));
-      )*
+        $str.push('>');
 
-      html.push('>');
+        // Add children (recursively process inner HTML)
+        html_write!($str; $($inner)*);
 
-      // Add children (recursively process inner HTML)
-      $(
-          html.push_str(&html!($inner));
-      )*
+        write!($str, "</{}>", stringify!($tag)).unwrap();
 
-      html.push_str(&format!("</{}>", stringify!($tag)));
-      html
-  }};
+        html_write!($str; $($rest)*);
+    };
 
-  // Match a single HTML element without attributes (self-closing tag)
-  ($tag:ident) => {{
-      format!("<{} />", stringify!($tag))
-  }};
+    // Match a single HTML element without attributes (self-closing tag)
+    ($str:expr; $tag:ident $($rest:tt)*) => {{
+        write!($str, "<{} />", stringify!($tag)).unwrap();
+        html_write!($str; $($rest)*);
+    }};
 
-  // Match plain text content
-  ($text:expr) => {{
-      $text.to_string()
-  }};
+    // Match plain text content
+    ($str:expr; $lit:literal $($rest:tt)*) => {{
+        write!($str, "{}", $lit).unwrap();
+        html_write!($str; $($rest)*);
+    }};
+
+    // Match arbitrary expression
+    ($str:expr; ($text:expr) $($rest:tt)*) => {{
+        write!($str, "{}", $text).unwrap();
+        html_write!($str; $($rest)*);
+    }};
+
+    // Nothing more, ends here
+    ($str:expr;) => {};
 }
+
+/// Example:
+/// ```rust
+/// let value = 1;
+/// let html = html!(
+///     p class="c",id="id" => { (value) }
+///     br
+///     "abc"
+/// );
+/// assert_eq!(html, r#"<p class="c",id="id">1</p><br />"abc""#)
+/// ```
+macro_rules! html {
+    ($($args:tt)*) => {{
+        use ::std::fmt::Write as _;
+        use $crate::html_macro::html_write;
+        let mut html = String::new();
+        html_write!(html; $($args)*);
+        html
+    }};
+}
+
+pub(crate) use {html, html_write};

--- a/src/process/footnote.rs
+++ b/src/process/footnote.rs
@@ -17,8 +17,8 @@ impl Processer for Footnote {
         let number = recorder.footnote_counter.entry(name.into()).or_insert(len);
         let id = get_back_id(s);
 
-        let html = html!(sup class="footnote-reference", id={id} => {
-          a href={format!("#{}", s)} => { (number) }
+        let html = html!(sup class="footnote-reference" id={id} {
+          a href={format!("#{}", s)} { (number) }
         });
         Some(html)
     }

--- a/src/process/footnote.rs
+++ b/src/process/footnote.rs
@@ -1,6 +1,6 @@
 use pulldown_cmark::{CowStr, Tag};
 
-use crate::{html, recorder::ParseRecorder};
+use crate::{html_macro::html, recorder::ParseRecorder};
 
 use super::processer::Processer;
 
@@ -17,8 +17,9 @@ impl Processer for Footnote {
         let number = recorder.footnote_counter.entry(name.into()).or_insert(len);
         let id = get_back_id(s);
 
-        let html = html!(sup class="footnote-reference", id={id} => 
-          (html!(a href={format!("#{}", s)} => {number})));
+        let html = html!(sup class="footnote-reference", id={id} => {
+          a href={format!("#{}", s)} => { (number) }
+        });
         Some(html)
     }
 
@@ -33,9 +34,7 @@ impl Processer for Footnote {
                 let html = format!(
                     r#"<div class="footnote-definition" id="{}">
   <sup class="footnote-definition-label"><a href="{}">{}</a></sup>"#,
-                    s,
-                    back_href, 
-                    number
+                    s, back_href, number
                 );
                 recorder.push(html);
             }

--- a/src/typst_cli.rs
+++ b/src/typst_cli.rs
@@ -69,7 +69,7 @@ pub fn source_to_inline_svg(src: &str, config: InlineConfig) -> Result<String, s
 
     Ok(format!(
         "\n{}\n",
-        html!(span class = "inline-typst" => { (svg) })
+        html!(span class="inline-typst" { (svg) })
     ))
 }
 

--- a/src/typst_cli.rs
+++ b/src/typst_cli.rs
@@ -2,7 +2,8 @@ use std::{fs, path::Path, process::Command};
 
 use crate::{
     config::{self, verify_and_file_hash},
-    html, html_flake,
+    html_flake,
+    html_macro::html,
 };
 
 pub fn source_to_inline_html(typst_path: &str, html_path: &str) -> Result<String, std::io::Error> {
@@ -68,7 +69,7 @@ pub fn source_to_inline_svg(src: &str, config: InlineConfig) -> Result<String, s
 
     Ok(format!(
         "\n{}\n",
-        html!(span class = "inline-typst" => {svg})
+        html!(span class = "inline-typst" => { (svg) })
     ))
 }
 
@@ -207,8 +208,7 @@ fn thematize(s: std::borrow::Cow<'_, str>) -> String {
 fn failed_in_file(src_pos: &'static str, file_path: &str, stderr: std::borrow::Cow<'_, str>) {
     eprintln!(
         "Command failed in {}: \n  In file {}, {}",
-        src_pos,
-        file_path,
-        stderr
+        src_pos, file_path, stderr
     );
 }
+


### PR DESCRIPTION
This PR rewrites the `html!` macro and adds a new `html_write!` macro to remove extra clones and nested `html!` calls.

The syntax is like:

```rust
let frag = html!{
  tag attr="literal" attr2=(expression) attr3={expression} { inner }
  self_closing_tag
  (inline_expression)
  "literals"
};

let mut s = String::new();
html_write!(s; tag ...);
```