### PR TITLE
Make `Slug` its own type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 clap = { version = "4.5.23", features = ["derive"] }
 eyre = "0.6.12"
 htmlize = { version = "1.0.5", features = ["unescape"]}
+internment = { version = "0.8.6", features = ["serde"] }
 pulldown-cmark = { version = "0.12.2", default-features = false, features = ["html"] }
 regex-lite = "0.1.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -19,14 +19,14 @@ use writer::Writer;
 
 use crate::{
     config::{self, verify_and_file_hash},
-    slug::{self, Ext},
+    slug::{self, Ext, Slug},
 };
 
 pub fn compile_all(workspace_dir: &str) -> eyre::Result<()> {
     let workspace = all_source_files(Path::new(workspace_dir))?;
     let mut shallows = HashMap::new();
 
-    for (slug, ext) in &workspace.slug_exts {
+    for (&slug, &ext) in &workspace.slug_exts {
         let relative_path = format!("{}.{}", slug, ext);
 
         let is_modified = verify_and_file_hash(&relative_path)
@@ -65,13 +65,13 @@ pub fn compile_all(workspace_dir: &str) -> eyre::Result<()> {
             shallow
         };
 
-        shallows.insert(slug.to_string(), shallow);
+        shallows.insert(slug, shallow);
     }
 
     let state = state::compile_all(shallows)?;
 
     Writer::write_needed_slugs(
-        &workspace.slug_exts.into_iter().map(|x| x.0).collect(),
+        workspace.slug_exts.into_iter().map(|x| x.0),
         &state,
     );
 
@@ -146,5 +146,5 @@ pub fn all_source_files(root_dir: &Path) -> eyre::Result<Workspace> {
 
 #[derive(Debug)]
 pub struct Workspace {
-    pub slug_exts: HashMap<String, Ext>,
+    pub slug_exts: HashMap<Slug, Ext>,
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -70,10 +70,7 @@ pub fn compile_all(workspace_dir: &str) -> eyre::Result<()> {
 
     let state = state::compile_all(shallows)?;
 
-    Writer::write_needed_slugs(
-        workspace.slug_exts.into_iter().map(|x| x.0),
-        &state,
-    );
+    Writer::write_needed_slugs(workspace.slug_exts.into_iter().map(|x| x.0), &state);
 
     Ok(())
 }
@@ -96,8 +93,9 @@ pub fn all_source_files(root_dir: &Path) -> eyre::Result<Workspace> {
     let mut slug_exts = HashMap::new();
     let to_slug_ext = |p: &Path| {
         let p = p.strip_prefix(root_dir).unwrap_or(p);
-        let (slug, ext) = slug::path_to_slug(p);
-        Some((slug, ext?))
+        let ext = p.extension()?.to_str()?.parse().ok()?;
+        let slug = Slug::new(slug::pretty_path(&p.with_extension("")));
+        Some((slug, ext))
     };
 
     let failed_to_read_dir = |dir: &Path| eyre!("failed to read directory `{}`", dir.display());

--- a/src/compiler/callback.rs
+++ b/src/compiler/callback.rs
@@ -1,15 +1,17 @@
 use std::collections::{HashMap, HashSet};
 
+use crate::slug::Slug;
+
 #[derive(Debug)]
 pub struct CallbackValue {
-    pub parent: String,
-    
+    pub parent: Slug,
+
     /// Used to record which sections reference the current section.
-    pub backlinks: HashSet<String>,
+    pub backlinks: HashSet<Slug>,
 }
 
 #[derive(Debug)]
-pub struct Callback(pub HashMap<String, CallbackValue>);
+pub struct Callback(pub HashMap<Slug, CallbackValue>);
 
 impl Callback {
     pub fn new() -> Callback {
@@ -20,7 +22,7 @@ impl Callback {
         other.0.into_iter().for_each(|(s, t)| self.insert(s, t));
     }
 
-    pub fn insert(&mut self, child_slug: String, value: CallbackValue) {
+    pub fn insert(&mut self, child_slug: Slug, value: CallbackValue) {
         match self.0.get(&child_slug) {
             None => {
                 self.0.insert(child_slug, value);
@@ -28,16 +30,16 @@ impl Callback {
             Some(_) => {
                 let mut existed = self.0.remove(&child_slug).unwrap();
                 existed.backlinks.extend(value.backlinks);
-                
+
                 if existed.parent == "index" && value.parent != "index" {
                     existed.parent = value.parent;
                 }
-                self.0.insert(child_slug.to_string(), existed);
+                self.0.insert(child_slug, existed);
             }
         }
     }
 
-    pub fn insert_parent(&mut self, child_slug: String, parent: String) {
+    pub fn insert_parent(&mut self, child_slug: Slug, parent: Slug) {
         self.insert(
             child_slug,
             CallbackValue {
@@ -47,14 +49,14 @@ impl Callback {
         );
     }
 
-    pub fn insert_backlinks<I>(&mut self, child_slug: String, backlinks: I)
+    pub fn insert_backlinks<I>(&mut self, child_slug: Slug, backlinks: I)
     where
-        I: IntoIterator<Item = String>,
+        I: IntoIterator<Item = Slug>,
     {
         self.insert(
             child_slug,
             CallbackValue {
-                parent: "index".to_string(),
+                parent: Slug::new("index"),
                 backlinks: HashSet::from_iter(backlinks),
             },
         );

--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -4,7 +4,7 @@ use eyre::{eyre, WrapErr};
 use pulldown_cmark::{html, CowStr, Event, Options, Tag, TagEnd};
 
 use crate::{
-    config::input_path, entry::HTMLMetaData, process::processer::Processer, recorder::ParseRecorder,
+    config::input_path, entry::HTMLMetaData, process::processer::Processer, recorder::ParseRecorder, slug::Slug,
 };
 
 use super::{
@@ -19,7 +19,7 @@ pub const OPTIONS: Options = Options::ENABLE_MATH
     .union(Options::ENABLE_FOOTNOTES);
 
 pub fn initialize(
-    slug: &str,
+    slug: Slug,
 ) -> eyre::Result<(String, HashMap<String, HTMLContent>, ParseRecorder)> {
     // global data store
     let mut metadata: HashMap<String, HTMLContent> = HashMap::new();
@@ -34,7 +34,7 @@ pub fn initialize(
         .wrap_err_with(|| eyre!("failed to read markdown file `{markdown_path}`"))
 }
 
-pub fn parse_markdown(slug: &str) -> eyre::Result<ShallowSection> {
+pub fn parse_markdown(slug: Slug) -> eyre::Result<ShallowSection> {
     let mut processers: Vec<Box<dyn Processer>> = vec![
         Box::new(crate::process::footnote::Footnote),
         Box::new(crate::process::figure::Figure),

--- a/src/compiler/section.rs
+++ b/src/compiler/section.rs
@@ -2,7 +2,10 @@ use regex_lite::Regex;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, mem, sync::LazyLock};
 
-use crate::entry::{EntryMetaData, HTMLMetaData, MetaData};
+use crate::{
+    entry::{EntryMetaData, HTMLMetaData, MetaData},
+    slug::Slug,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SectionOption {
@@ -40,7 +43,7 @@ pub struct EmbedContent {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalLink {
-    pub slug: String,
+    pub slug: Slug,
     pub text: Option<String>,
 }
 
@@ -181,8 +184,8 @@ pub struct ShallowSection {
 }
 
 impl ShallowSection {
-    pub fn slug(&self) -> String {
-        self.metadata.slug().unwrap().to_string()
+    pub fn slug(&self) -> Slug {
+        self.metadata.slug().unwrap()
     }
 
     #[allow(dead_code)]
@@ -204,14 +207,14 @@ pub struct Section {
     pub metadata: EntryMetaData,
     pub children: SectionContents,
     pub option: SectionOption,
-    pub references: HashSet<String>,
+    pub references: HashSet<Slug>,
 }
 
 impl Section {
     pub fn new(
         metadata: EntryMetaData,
         children: SectionContents,
-        references: HashSet<String>,
+        references: HashSet<Slug>,
     ) -> Section {
         Section {
             metadata,
@@ -221,8 +224,8 @@ impl Section {
         }
     }
 
-    pub fn slug(&self) -> String {
-        self.metadata.slug().unwrap().to_string()
+    pub fn slug(&self) -> Slug {
+        self.metadata.slug().unwrap()
     }
 
     pub fn spanned(&self) -> String {

--- a/src/compiler/typst.rs
+++ b/src/compiler/typst.rs
@@ -6,7 +6,7 @@ use super::section::{HTMLContent, HTMLContentBuilder, LazyContent};
 use super::ShallowSection;
 use crate::entry::HTMLMetaData;
 use crate::process::embed_markdown;
-use crate::slug::to_slug;
+use crate::slug::{to_slug, Slug};
 use crate::typst_cli;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -91,7 +91,7 @@ fn parse_typst_html(
     Ok(builder.build())
 }
 
-pub fn parse_typst(slug: &str, root_dir: &str) -> eyre::Result<ShallowSection> {
+pub fn parse_typst(slug: Slug, root_dir: &str) -> eyre::Result<ShallowSection> {
     let relative_path = format!("{}.typst", slug);
     let html_str = typst_cli::file_to_html(&relative_path, root_dir)
         .wrap_err_with(|| eyre!("failed to compile typst file `{relative_path}` to html"))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,8 @@ use std::{
 
 use walkdir::WalkDir;
 
+use crate::slug::Slug;
+
 #[derive(Clone, clap::ValueEnum)]
 pub enum FooterMode {
     Link,
@@ -171,7 +173,7 @@ pub fn full_url(path: &str) -> String {
     format!("{}{}", base_url(), path)
 }
 
-pub fn full_html_url(slug: &str) -> String {
+pub fn full_html_url(slug: Slug) -> String {
     full_url(&format!("{}{}", slug, lock_config().page_suffix))
 }
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,7 +1,7 @@
 use crate::{
     compiler::{section::HTMLContent, taxon::Taxon},
     config,
-    html_flake,
+    html_flake, slug::Slug,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::{hash_map::Keys, HashMap};
@@ -101,8 +101,8 @@ where
         return self.get_str(KEY_PAGE_TITLE);
     }
 
-    fn slug(&self) -> Option<&String> {
-        return self.get_str(KEY_SLUG);
+    fn slug(&self) -> Option<Slug> {
+        return self.get_str(KEY_SLUG).map(Slug::new);
     }
 
     fn is_enable_backlinks(&self) -> bool {
@@ -175,16 +175,16 @@ impl EntryMetaData {
         let entry_title = self.0.get("title").map(|s| s.as_str()).unwrap_or("");
         let title = adhoc_title.unwrap_or(entry_title);
 
-        let slug = self.get("slug").unwrap();
-        let slug_text = EntryMetaData::to_slug_text(&slug);
-        let slug_url = config::full_html_url(&slug);
+        let slug = Slug::new(self.get("slug").unwrap());
+        let slug_text = EntryMetaData::to_slug_text(slug.as_str());
+        let slug_url = config::full_html_url(slug);
         let span_class: Vec<String> = vec!["taxon".to_string()];
 
         html_flake::html_header(title, taxon, &slug_url, &slug_text, span_class.join(" "), self.etc())
     }
 
     /// hidden suffix `/index` in slug text.
-    pub fn to_slug_text(slug: &String) -> String {
+    pub fn to_slug_text(slug: &str) -> String {
         let mut slug_text = match slug.ends_with("/index") {
             true => &slug[..slug.len() - "/index".len()],
             false => slug,

--- a/src/html_flake.rs
+++ b/src/html_flake.rs
@@ -3,7 +3,7 @@ use std::ops::Not;
 use crate::{
     config,
     entry::{EntryMetaData, MetaData},
-    html_macro::html,
+    html_macro::html, slug::Slug,
 };
 
 pub fn html_article_inner(
@@ -84,7 +84,7 @@ pub fn html_header(
 }
 
 pub fn catalog_item(
-    slug: &str,
+    slug: Slug,
     title: &str,
     page_title: &str,
     details_open: bool,
@@ -93,7 +93,7 @@ pub fn catalog_item(
 ) -> String {
     let slug_url = config::full_html_url(slug);
     let title_text = format!("{} [{}]", page_title, slug);
-    let onclick = format!("window.location.href='#{}'", crate::slug::to_hash_id(slug));
+    let onclick = format!("window.location.href='#{}'", crate::slug::to_hash_id(slug.as_str()));
 
     let mut class_name: Vec<String> = vec![];
     if !details_open {

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -92,20 +92,18 @@ pub fn to_hash_id(slug_str: &str) -> String {
 
 /// path to slug
 pub fn to_slug(fullname: &str) -> Slug {
-    path_to_slug(Path::new(fullname)).0
+    let path = Path::new(fullname);
+    let slug = strip_base(path).with_extension("");
+    Slug::new(pretty_path(&slug))
 }
 
-pub fn path_to_slug(path: &Path) -> (Slug, Option<Ext>) {
-    let slug = path
-        // this works for both windows and unix
+/// Strip `./` or `/` from a `Path` if exists.
+/// Works on both Windows and \*nix.
+fn strip_base(path: &Path) -> &Path {
+    path
         .strip_prefix("./")
         .or_else(|_| path.strip_prefix("/"))
-        .unwrap_or(path);
-    let ext = slug
-        .extension()
-        .and_then(|e| e.to_str())
-        .and_then(|e| e.parse().ok());
-    (Slug::new(pretty_path(&slug.with_extension(""))), ext)
+        .unwrap_or(path)
 }
 
 pub fn pretty_path(path: &std::path::Path) -> String {

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -3,8 +3,7 @@ use std::{fmt::Display, path::Path, str::FromStr};
 use internment::Intern;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
-#[serde(from = "String")]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Slug(Intern<str>);
 
 impl Slug {
@@ -14,12 +13,6 @@ impl Slug {
 
     pub fn as_str(&self) -> &'static str {
         self.0.as_ref()
-    }
-}
-
-impl From<String> for Slug {
-    fn from(value: String) -> Self {
-        Self::new(value)
     }
 }
 
@@ -47,6 +40,15 @@ impl Serialize for Slug {
         S: serde::Serializer,
     {
         serializer.serialize_str(self.0.as_ref())
+    }
+}
+
+impl<'de> Deserialize<'de> for Slug {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(Slug::new)
     }
 }
 

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -93,17 +93,7 @@ pub fn to_hash_id(slug_str: &str) -> String {
 /// path to slug
 pub fn to_slug(fullname: &str) -> Slug {
     let path = Path::new(fullname);
-    let slug = strip_base(path).with_extension("");
-    Slug::new(pretty_path(&slug))
-}
-
-/// Strip `./` or `/` from a `Path` if exists.
-/// Works on both Windows and \*nix.
-fn strip_base(path: &Path) -> &Path {
-    path
-        .strip_prefix("./")
-        .or_else(|_| path.strip_prefix("/"))
-        .unwrap_or(path)
+    Slug::new(pretty_path(&path.with_extension("")))
 }
 
 pub fn pretty_path(path: &std::path::Path) -> String {
@@ -118,7 +108,7 @@ fn clean_path(path: &std::path::Path) -> std::path::PathBuf {
     let mut cleaned_path = std::path::PathBuf::new();
     for component in path.components() {
         match component {
-            std::path::Component::CurDir => {}
+            std::path::Component::RootDir | std::path::Component::CurDir => {}
             std::path::Component::ParentDir => {
                 cleaned_path.pop();
             }


### PR DESCRIPTION
This PR introduces `Slug`, an interned string type representing a slug. Related functions that formerly accept and return strings have been changed to use `Slug` when appropriate. Functions cleaning and stripping paths in `slug.rs` are also modified a bit to avoid interning unrelated paths.