### PR TITLE
Breaking change: make relative URLs relative

### DIFF
--- a/src/compiler/section.rs
+++ b/src/compiler/section.rs
@@ -47,7 +47,7 @@ pub struct EmbedContent {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalLink {
-    pub slug: Slug,
+    pub url: String,
     pub text: Option<String>,
 }
 

--- a/src/compiler/typst.rs
+++ b/src/compiler/typst.rs
@@ -11,7 +11,7 @@ use super::ShallowSection;
 use crate::entry::HTMLMetaData;
 use crate::ordered_map::OrderedMap;
 use crate::process::embed_markdown;
-use crate::slug::{to_slug, Slug};
+use crate::slug::Slug;
 use crate::typst_cli;
 use std::borrow::Cow;
 use std::path::Path;
@@ -83,9 +83,9 @@ fn parse_typst_html(
                 }))
             }
             HTMLTagKind::Local { span: _ } => {
-                let slug = to_slug(attr("slug")?.to_string());
+                let url = attr("slug")?.to_string();
                 let text = value();
-                builder.push(LazyContent::Local(LocalLink { slug, text }))
+                builder.push(LazyContent::Local(LocalLink { url, text }))
             }
         }
     }
@@ -98,9 +98,8 @@ fn parse_typst_html(
 pub fn parse_typst<P: AsRef<Path>>(slug: Slug, root_dir: P) -> eyre::Result<ShallowSection> {
     let typst_root_dir = root_dir.as_ref().to_string_lossy();
     let relative_path = format!("{}.typst", slug);
-    let html_str =
-        typst_cli::file_to_html(&relative_path, typst_root_dir.as_ref())
-            .wrap_err_with(|| eyre!("failed to compile typst file `{relative_path}` to html"))?;
+    let html_str = typst_cli::file_to_html(&relative_path, typst_root_dir.as_ref())
+        .wrap_err_with(|| eyre!("failed to compile typst file `{relative_path}` to html"))?;
 
     let mut metadata: OrderedMap<String, HTMLContent> = OrderedMap::new();
     metadata.insert("slug".to_string(), HTMLContent::Plain(slug.to_string()));

--- a/src/config.rs
+++ b/src/config.rs
@@ -172,16 +172,6 @@ pub fn full_html_url(slug: Slug) -> String {
     full_url(format!("{}{}", slug, page_suffix))
 }
 
-/// Convert `path` to `./{path}` (starts with `/`) or `path`.
-///
-/// This function keep posix style for the path, so it will return a [`String`].
-pub fn relativize(path: &str) -> String {
-    match path.starts_with("/") {
-        true => format!(".{}", path),
-        _ => path.to_string(),
-    }
-}
-
 pub fn parent_dir<P: AsRef<Path>>(path: P) -> (PathBuf, PathBuf) {
     let binding = path.as_ref();
     let filename = binding.file_name().expect("Path must have a filename");

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod entry;
 mod html_flake;
 mod html_macro;
 mod ordered_map;
+mod path_utils;
 mod process;
 mod recorder;
 mod slug;
@@ -43,7 +44,7 @@ enum Command {
     Build(BuildCommand),
 
     /// Serves a forest at http://localhost:8080, and rebuilds it on changes.
-    /// 
+    ///
     /// Server temporarily depends on the miniserve program in the user's environment.
     #[command(visible_alias = "s")]
     Serve(ServeCommand),

--- a/src/path_utils.rs
+++ b/src/path_utils.rs
@@ -1,0 +1,13 @@
+use std::path::{Path, PathBuf};
+
+pub fn relative_to_current<P1, P2>(current: P1, target: P2) -> PathBuf
+where
+    P1: AsRef<Path>,
+    P2: AsRef<Path>,
+{
+    if let Some(parent) = current.as_ref().parent() {
+        parent.join(target)
+    } else {
+        target.as_ref().to_owned()
+    }
+}

--- a/src/process/embed_markdown.rs
+++ b/src/process/embed_markdown.rs
@@ -9,7 +9,6 @@ use crate::{
     compiler::section::{EmbedContent, LocalLink, SectionOption},
     html_flake::html_link,
     recorder::State,
-    slug::to_slug,
 };
 use pulldown_cmark::{html, Event, Tag, TagEnd};
 
@@ -67,7 +66,6 @@ impl<'e, E: Iterator<Item = Event<'e>>> Iterator for Embed<'e, E> {
                 Event::End(TagEnd::Link) => match self.state {
                     State::Embed => {
                         let (url, mut content) = self.exit();
-                        let url = crate::config::relativize(&url);
 
                         let mut option = SectionOption::default();
                         let title = if let Some(e) = content.first_mut() {
@@ -95,13 +93,7 @@ impl<'e, E: Iterator<Item = Event<'e>>> Iterator for Embed<'e, E> {
                             html::push_html(&mut text, content.into_iter());
                             Some(text)
                         };
-                        return Some(
-                            LocalLink {
-                                slug: to_slug(&url),
-                                text,
-                            }
-                            .into(),
-                        );
+                        return Some(LocalLink { url, text }.into());
                     }
                     State::ExternalLink => {
                         let (url, content) = self.exit();

--- a/src/process/typst_image.rs
+++ b/src/process/typst_image.rs
@@ -7,9 +7,10 @@ use std::{fmt::Write, fs, path::PathBuf};
 use crate::{
     config::{self, output_path, parent_dir},
     html_flake::{html_figure, html_figure_code},
+    path_utils,
     recorder::State,
     slug::Slug,
-    typst_cli::{self, write_to_inline_html, write_svg, InlineConfig},
+    typst_cli::{self, write_svg, write_to_inline_html, InlineConfig},
 };
 use pulldown_cmark::{Event, Tag, TagEnd};
 
@@ -86,14 +87,15 @@ impl<'e, E: Iterator<Item = Event<'e>>> Iterator for TypstImage<E> {
                 }
                 Event::End(TagEnd::Link) => match self.state {
                     State::Html => {
-                        let typst_url = config::relativize(&self.url.take().unwrap());
+                        let typst_url =
+                            typst_path(self.current_slug, &self.url.take().unwrap_or_default());
                         let (parent_dir, filename) = parent_dir(&typst_url);
 
                         let mut html_url = filename.with_extension("html");
                         let img_src = parent_dir.join(&html_url);
                         html_url = output_path(&img_src);
 
-                        let html = match write_to_inline_html(PathBuf::from(typst_url), html_url) {
+                        let html = match write_to_inline_html(typst_url, html_url) {
                             Ok(inline_html) => inline_html,
                             Err(err) => {
                                 eprintln!("{:?} at {}", err, self.current_slug);
@@ -137,16 +139,16 @@ impl<'e, E: Iterator<Item = Event<'e>>> Iterator for TypstImage<E> {
                         return Some(Event::Html(html.into()));
                     }
                     State::ImageSpan => {
-                        let typst_url = self.url.as_ref().unwrap();
+                        let typst_url =
+                            typst_path(self.current_slug, &self.url.take().unwrap_or_default());
                         let caption = self.content.take().unwrap_or_default();
-                        let typst_url = config::relativize(typst_url);
                         let (parent_dir, filename) = parent_dir(&typst_url);
 
                         let mut svg_url = filename.with_extension("svg");
                         let img_src = parent_dir.join(&svg_url);
                         svg_url = output_path(&img_src);
 
-                        if let Err(err) = write_svg(PathBuf::from(typst_url), svg_url) {
+                        if let Err(err) = write_svg(typst_url, svg_url) {
                             eprintln!("{:?} at {}", err, self.current_slug)
                         }
                         self.exit();
@@ -155,16 +157,16 @@ impl<'e, E: Iterator<Item = Event<'e>>> Iterator for TypstImage<E> {
                         return Some(Event::Html(html.into()));
                     }
                     State::ImageBlock => {
-                        let typst_url = self.url.as_ref().unwrap();
+                        let typst_url =
+                            typst_path(self.current_slug, &self.url.take().unwrap_or_default());
                         let caption = self.content.take().unwrap_or_default();
-                        let typst_url = config::relativize(typst_url);
                         let (parent_dir, filename) = parent_dir(&typst_url);
 
                         let mut svg_url = filename.with_extension("svg");
                         let img_src = parent_dir.join(&svg_url);
                         svg_url = output_path(&img_src);
 
-                        if let Err(err) = write_svg(PathBuf::from(typst_url), svg_url) {
+                        if let Err(err) = write_svg(typst_url, svg_url) {
                             eprintln!("{:?} at {}", err, self.current_slug)
                         }
                         self.exit();
@@ -173,16 +175,16 @@ impl<'e, E: Iterator<Item = Event<'e>>> Iterator for TypstImage<E> {
                         return Some(Event::Html(html.into()));
                     }
                     State::ImageCode => {
-                        let typst_url = self.url.as_ref().unwrap();
+                        let typst_url =
+                            typst_path(self.current_slug, &self.url.take().unwrap_or_default());
                         let caption = self.content.take().unwrap_or_default();
-                        let typst_url = config::relativize(typst_url);
                         let (parent_dir, filename) = parent_dir(&typst_url);
 
                         let mut svg_url = filename.with_extension("svg");
                         let img_src = parent_dir.join(&svg_url);
                         svg_url = output_path(&img_src);
 
-                        if let Err(err) = write_svg(PathBuf::from(&typst_url), svg_url) {
+                        if let Err(err) = write_svg(&typst_url, &svg_url) {
                             eprintln!("{:?} at {}", err, self.current_slug)
                         }
                         self.exit();
@@ -230,4 +232,13 @@ fn allow_inline(state: &State) -> bool {
 pub fn is_inline_typst(dest_url: &str) -> bool {
     let key = State::InlineTypst.strify();
     dest_url == key || dest_url.starts_with(&format!("{}-", key))
+}
+
+fn typst_path(current_slug: Slug, url: &str) -> PathBuf {
+    let path = path_utils::relative_to_current(current_slug.as_str(), url);
+    if let Ok(rest) = path.strip_prefix("/") {
+        rest.to_owned()
+    } else {
+        path
+    }
 }


### PR DESCRIPTION
This PR makes the base of relative URLs in **markdown links**  to be the file containing the link. For example, `[](./b.md)` in `trees/deep/a.md` resolves to `trees/deep/b.md`. Same applies to linked `typ` files.

A known problem is that paths in **inline typst** resolves based on the project root instead of current calling file due to limitation in the typst CLI. Other things should behave consistently right now.