### PR TITLE
Replace `Path`s with `camino` provided ones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "camino"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+
+[[package]]
 name = "clap"
 version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +393,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 name = "kodama"
 version = "0.3.0"
 dependencies = [
+ "camino",
  "clap",
  "eyre",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ notify = "8.0.0"
 itertools = "0.14.0"
 toml = "0.9.0"
 url = "2.5.4"
+camino = "1.1.10"
 
 [profile.release]
 strip = true

--- a/src/assets_sync.rs
+++ b/src/assets_sync.rs
@@ -1,44 +1,48 @@
 // Copyright (c) 2025 Kodama Project. All rights reserved.
 // Released under the GPL-3.0 license as described in the file LICENSE.
-// Authors: Kokic (@kokic)
+// Authors: Kokic (@kokic), Spore (@s-cerevisiae)
 
 use std::fs::{self};
-use std::path::Path;
-use walkdir::WalkDir;
+
+use camino::{Utf8Path, Utf8PathBuf};
 use eyre::eyre;
+use walkdir::WalkDir;
 
 /// Synchronizes files from source directory to target directory recursively based on modification time.
 /// If all files in source (including subdirectories) have the same modification time as in target,
-/// the function exits early. If any file in source is newer, it is copied to target. 
-/// 
-/// Return `true` if all files have same modification time. 
-pub fn sync_assets<P: AsRef<Path>>(source: P , target: P) -> eyre::Result<bool> {
+/// the function exits early. If any file in source is newer, it is copied to target.
+///
+/// Return `true` if all files have same modification time.
+pub fn sync_assets<P: AsRef<Utf8Path>>(source: P, target: P) -> eyre::Result<bool> {
     let source_path = source.as_ref();
     let target_path = target.as_ref();
 
     if !source_path.exists() {
-        return Ok(true)
+        return Ok(true);
     }
 
     // Ensure target directory exists
     if !target_path.exists() {
         fs::create_dir_all(target_path)?;
     } else if !target_path.is_dir() {
-        return Err(eyre!("target path is not a directory: {}", target_path.display()));
+        return Err(eyre!("target path is not a directory: {}", target_path));
     }
 
     // Flag to track if all files have same modification time
     let mut all_same_mtime = true;
 
     let walkdir = WalkDir::new(source_path);
-    for entry in walkdir.into_iter().filter_map(|e| e.ok()) {
-        let source_file_path = entry.path();
+    for source_file_path in walkdir.into_iter().filter_map(|e| {
+        e.ok()
+            .and_then(|e| Utf8PathBuf::from_path_buf(e.into_path()).ok())
+    }) {
         if !source_file_path.is_file() {
             continue;
         }
 
-        let relative_path = source_file_path.strip_prefix(source_path)    
-        .map_err(|_| eyre::eyre!("failed to compute relative path for {}", source_file_path.display()))?;
+        let relative_path = source_file_path
+            .strip_prefix(source_path)
+            .map_err(|_| eyre::eyre!("failed to compute relative path for {}", source_file_path))?;
 
         let target_file_path = target_path.join(relative_path);
 

--- a/src/cli/build.rs
+++ b/src/cli/build.rs
@@ -1,9 +1,11 @@
 // Copyright (c) 2025 Kodama Project. All rights reserved.
 // Released under the GPL-3.0 license as described in the file LICENSE.
-// Authors: Kokic (@kokic)
+// Authors: Kokic (@kokic), Spore (@s-cerevisiae)
 
+use std::fs;
+
+use camino::{Utf8Path, Utf8PathBuf};
 use eyre::{eyre, WrapErr};
-use std::{fs, path::PathBuf};
 
 use crate::{
     assets_sync,
@@ -26,7 +28,7 @@ pub fn build(command: &BuildCommand) -> eyre::Result<()> {
 
 pub fn build_with(config: String, mode: BuildMode) -> eyre::Result<()> {
     let _ = config::BUILD_MODE.set(mode);
-    config_toml::apply_config(PathBuf::from(config))?;
+    config_toml::apply_config(Utf8PathBuf::from(config))?;
 
     if !config::inline_css() {
         export_css_files().wrap_err("failed to export CSS")?;
@@ -54,10 +56,10 @@ fn export_css_files() -> eyre::Result<()> {
 
 fn export_css_file(css_content: &str, name: &str) -> eyre::Result<()> {
     let path = output_path(name);
-    let path = std::path::Path::new(&path);
+    let path = Utf8Path::new(&path);
     if !path.exists() {
         fs::write(path, css_content)
-            .wrap_err_with(|| eyre!("failed to write CSS file to \"{}\"", path.display()))?;
+            .wrap_err_with(|| eyre!("failed to write CSS file to \"{}\"", path))?;
     }
     Ok(())
 }

--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -1,9 +1,8 @@
 // Copyright (c) 2025 Kodama Project. All rights reserved.
 // Released under the GPL-3.0 license as described in the file LICENSE.
-// Authors: Kokic (@kokic)
+// Authors: Kokic (@kokic), Spore (@s-cerevisiae)
 
-use std::path::PathBuf;
-
+use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 use eyre::Context;
 
@@ -34,17 +33,17 @@ pub enum NewCommand {
 pub struct NewSiteCommand {
     /// Path to the new site.
     #[arg(required = true)]
-    pub path: PathBuf,
+    pub path: Utf8PathBuf,
 }
 
 pub fn new_site(command: &NewSiteCommand) -> eyre::Result<()> {
     let site_path = &command.path;
     if site_path.exists() {
-        return Err(eyre::eyre!("Already exists: {}", site_path.display()));
+        return Err(eyre::eyre!("Already exists: {}", site_path));
     }
 
     std::fs::create_dir_all(site_path).wrap_err("failed to create site directory")?;
-    println!("Created new site at: {}", site_path.display());
+    println!("Created new site at: {}", site_path);
 
     let default_config_path = site_path.join(config_toml::DEFAULT_CONFIG_PATH);
     let default_source_dir = site_path.join(config_toml::DEFAULT_SOURCE_DIR);
@@ -63,7 +62,7 @@ pub fn new_site(command: &NewSiteCommand) -> eyre::Result<()> {
 
     // Create the `index.md` section in the new site directory
     new_section_inner(
-        &PathBuf::from(DEFAULT_SECTION_PATH),
+        &Utf8PathBuf::from(DEFAULT_SECTION_PATH),
         DEFAULT_TEMPLATE,
         &default_config_path,
     )?;
@@ -79,15 +78,15 @@ pub struct NewConfigCommand {
 }
 
 pub fn new_config(command: &NewConfigCommand) -> eyre::Result<()> {
-    new_config_inner(&PathBuf::from(&command.path))
+    new_config_inner(&Utf8PathBuf::from(&command.path))
 }
 
-fn new_config_inner(config_path: &PathBuf) -> Result<(), eyre::Error> {
+fn new_config_inner(config_path: &Utf8PathBuf) -> Result<(), eyre::Error> {
     let config = config_toml::Config::default();
     let toml = toml::to_string(&config).wrap_err("failed to serialize default config")?;
 
     std::fs::write(config_path, toml).wrap_err("failed to create default config file")?;
-    println!("Created new config at: {}", config_path.display());
+    println!("Created new config at: {}", config_path);
     Ok(())
 }
 
@@ -104,7 +103,7 @@ title: <FILE_NAME>
 pub struct NewPostCommand {
     /// Path to the new section.
     #[arg(required = true)]
-    pub path: PathBuf,
+    pub path: Utf8PathBuf,
 
     /// Path to the template file to use for the new section.
     #[arg(short, long, default_value_t = DEFAULT_TEMPLATE.to_string())]
@@ -120,13 +119,13 @@ pub fn new_section(command: &NewPostCommand) -> eyre::Result<()> {
     new_section_inner(
         &command.path,
         &command.template,
-        &PathBuf::from(&command.config),
+        Utf8Path::new(&command.config),
     )
 }
 
 /// This function invoked the [`config_toml::apply_config`] function to apply the configuration.
-fn new_section_inner(path: &PathBuf, template: &str, config: &PathBuf) -> eyre::Result<()> {
-    config_toml::apply_config(PathBuf::from(config))?;
+fn new_section_inner(path: &Utf8Path, template: &str, config: &Utf8Path) -> eyre::Result<()> {
+    config_toml::apply_config(config.to_owned())?;
 
     let default_not_exists = template == DEFAULT_TEMPLATE && !std::fs::exists(template)?;
 
@@ -137,14 +136,13 @@ fn new_section_inner(path: &PathBuf, template: &str, config: &PathBuf) -> eyre::
             .map_err(|e| eyre::eyre!("failed to read template file: {}", e))?
     };
 
-    let filestem = path.file_stem().unwrap().to_str().unwrap();
+    let filestem = path.file_stem().unwrap();
     let content = content.replace("<FILE_NAME>", filestem);
 
     let section_path = config::trees_dir().join(path);
-    let section_path_display = section_path.display();
 
     if section_path.exists() {
-        return Err(eyre::eyre!("already exists: {}", section_path_display));
+        return Err(eyre::eyre!("already exists: {}", section_path));
     } else {
         std::fs::create_dir_all(section_path.parent().unwrap())
             .map_err(|e| eyre::eyre!("failed to create section directory: {}", e))?;
@@ -152,7 +150,7 @@ fn new_section_inner(path: &PathBuf, template: &str, config: &PathBuf) -> eyre::
 
     std::fs::write(&section_path, content)
         .map_err(|e| eyre::eyre!("failed to create section file: {}", e))?;
-    println!("Created new section at: {}", section_path_display);
+    println!("Created new section at: {}", section_path);
 
     Ok(())
 }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -12,9 +12,10 @@ pub mod taxon;
 pub mod typst;
 pub mod writer;
 
-use std::{collections::HashMap, fs::File, io::BufReader, path::Path};
+use std::{collections::HashMap, fs::File, io::BufReader};
 
-use eyre::{bail, eyre, Ok, WrapErr};
+use camino::{Utf8Path, Utf8PathBuf};
+use eyre::{bail, eyre, WrapErr};
 use parser::parse_markdown;
 use section::{HTMLContent, ShallowSection};
 use typst::parse_typst;
@@ -23,7 +24,8 @@ use writer::Writer;
 
 use crate::{
     config::{self, verify_and_file_hash},
-    slug::{self, Ext, Slug},
+    path_utils,
+    slug::{Ext, Slug},
 };
 
 pub fn compile(workspace: Workspace) -> eyre::Result<()> {
@@ -34,22 +36,18 @@ pub fn compile(workspace: Workspace) -> eyre::Result<()> {
 
         let is_modified = match config::is_serve() {
             true => verify_and_file_hash(&relative_path)
-            .wrap_err_with(|| eyre!("failed to verify hash of `{relative_path}`"))?,
+                .wrap_err_with(|| eyre!("failed to verify hash of `{relative_path}`"))?,
             false => true,
         };
-        
+
         let entry_path = config::entry_file_path(&relative_path);
         let shallow = if !is_modified && entry_path.exists() {
-            let entry_file = BufReader::new(File::open(&entry_path).wrap_err_with(|| {
-                eyre!("failed to open entry file at `{}`", entry_path.display())
-            })?);
-            let shallow: ShallowSection =
-                serde_json::from_reader(entry_file).wrap_err_with(|| {
-                    eyre!(
-                        "failed to deserialize entry file at `{}`",
-                        entry_path.display()
-                    )
-                })?;
+            let entry_file = BufReader::new(
+                File::open(&entry_path)
+                    .wrap_err_with(|| eyre!("failed to open entry file at `{}`", entry_path))?,
+            );
+            let shallow: ShallowSection = serde_json::from_reader(entry_file)
+                .wrap_err_with(|| eyre!("failed to deserialize entry file at `{}`", entry_path))?;
             shallow
         } else {
             let shallow = match ext {
@@ -60,7 +58,7 @@ pub fn compile(workspace: Workspace) -> eyre::Result<()> {
             };
             let serialized = serde_json::to_string(&shallow).unwrap();
             std::fs::write(&entry_path, serialized)
-                .wrap_err_with(|| eyre!("failed to write entry to `{}`", entry_path.display()))?;
+                .wrap_err_with(|| eyre!("failed to write entry to `{}`", entry_path))?;
 
             shallow
         };
@@ -74,46 +72,45 @@ pub fn compile(workspace: Workspace) -> eyre::Result<()> {
     Ok(())
 }
 
-pub fn should_ignored_file(path: &Path) -> bool {
+pub fn should_ignored_file(path: &Utf8Path) -> bool {
     let name = path.file_name().unwrap();
     name == "README.md"
 }
 
-pub fn should_ignored_dir(path: &Path) -> bool {
-    let name = path.file_name().unwrap();
-    name.to_str()
-        .is_some_and(|s| s.starts_with('.') || s.starts_with('_'))
+pub fn should_ignored_dir(path: &Utf8Path) -> bool {
+    path.file_name().unwrap().starts_with(['.', '_'])
 }
 
-fn to_slug_ext(source_dir: &Path, p: &Path) -> Option<(Slug, Ext)> {
+fn to_slug_ext(source_dir: &Utf8Path, p: &Utf8Path) -> Option<(Slug, Ext)> {
     let p = p.strip_prefix(source_dir).unwrap_or(p);
-    let ext = p.extension()?.to_str()?.parse().ok()?;
-    let slug = Slug::new(slug::pretty_path(&p.with_extension("")));
+    let ext = p.extension()?.parse().ok()?;
+    let slug = Slug::new(path_utils::pretty_path(&p.with_extension("")));
     Some((slug, ext))
 }
 
 /// Collect all source file paths in workspace dir.
 ///
 /// It includes all `.md` and `.typ` files in the `trees_dir`.
-pub fn all_trees_source(trees_dir: &Path) -> eyre::Result<Workspace> {
+pub fn all_trees_source(trees_dir: &Utf8Path) -> eyre::Result<Workspace> {
     let mut slug_exts = HashMap::new();
 
-    let failed_to_read_dir = |dir: &Path| eyre!("failed to read directory `{}`", dir.display());
-    let file_collide = |p: &Path, e: Ext| {
+    let failed_to_read_dir = |dir: &Utf8Path| eyre!("failed to read directory `{}`", dir);
+    let file_collide = |p: &Utf8Path, e: Ext| {
         eyre!(
             "`{}` collides with `{}`",
-            p.display(),
-            p.with_extension(e.to_string()).display(),
+            p,
+            p.with_extension(e.to_string()),
         )
     };
 
-    let mut collect_files = |source_dir: &Path| {
-        for entry in
-            std::fs::read_dir(source_dir).wrap_err_with(|| failed_to_read_dir(source_dir))?
+    let mut collect_files = |source_dir: &Utf8Path| {
+        for entry in source_dir
+            .read_dir_utf8()
+            .wrap_err_with(|| failed_to_read_dir(source_dir))?
         {
             let path = entry
                 .wrap_err_with(|| failed_to_read_dir(source_dir))?
-                .path();
+                .into_path();
             if path.is_file() && !should_ignored_file(&path) {
                 let Some((slug, ext)) = to_slug_ext(source_dir, &path) else {
                     continue;
@@ -126,13 +123,15 @@ pub fn all_trees_source(trees_dir: &Path) -> eyre::Result<Workspace> {
                     .follow_links(true)
                     .into_iter()
                     .filter_entry(|e| {
-                        let path = e.path();
-                        path.is_file() || !should_ignored_dir(path)
+                        Utf8Path::from_path(e.path())
+                            .is_some_and(|p| p.is_file() || !should_ignored_dir(p))
                     })
                 {
-                    let path = entry
+                    let path: Utf8PathBuf = entry
                         .wrap_err_with(|| failed_to_read_dir(&path))?
-                        .into_path();
+                        .into_path()
+                        .try_into()
+                        .expect("non-UTF-8 paths are filtered out");
                     if path.is_file() {
                         let Some((slug, ext)) = to_slug_ext(source_dir, &path) else {
                             continue;
@@ -150,7 +149,7 @@ pub fn all_trees_source(trees_dir: &Path) -> eyre::Result<Workspace> {
     if !trees_dir.exists() {
         eprintln!(
             "Warning: Source directory `{}` does not exist, skipping.",
-            trees_dir.display()
+            trees_dir
         );
     }
 

--- a/src/compiler/typst.rs
+++ b/src/compiler/typst.rs
@@ -2,6 +2,7 @@
 // Released under the GPL-3.0 license as described in the file LICENSE.
 // Authors: Alias Qli (@AliasQli), Spore (@s-cerevisiae), Kokic (@kokic)
 
+use camino::Utf8Path;
 use eyre::{eyre, WrapErr};
 
 use super::html_parser::{HTMLParser, HTMLTagKind};
@@ -14,7 +15,6 @@ use crate::process::embed_markdown;
 use crate::slug::Slug;
 use crate::typst_cli;
 use std::borrow::Cow;
-use std::path::Path;
 use std::str;
 
 fn parse_bool(m: Option<&Cow<'_, str>>, def: bool) -> bool {
@@ -95,8 +95,8 @@ fn parse_typst_html(
     Ok(builder.build())
 }
 
-pub fn parse_typst<P: AsRef<Path>>(slug: Slug, root_dir: P) -> eyre::Result<ShallowSection> {
-    let typst_root_dir = root_dir.as_ref().to_string_lossy();
+pub fn parse_typst<P: AsRef<Utf8Path>>(slug: Slug, root_dir: P) -> eyre::Result<ShallowSection> {
+    let typst_root_dir = root_dir.as_ref();
     let relative_path = format!("{}.typst", slug);
     let html_str = typst_cli::file_to_html(&relative_path, typst_root_dir.as_ref())
         .wrap_err_with(|| eyre!("failed to compile typst file `{relative_path}` to html"))?;

--- a/src/compiler/writer.rs
+++ b/src/compiler/writer.rs
@@ -30,7 +30,7 @@ impl Writer {
         let relative_path = config::output_dir().join(&html_url);
         if verify_update_hash(&relative_path, &html).expect("failed to verify update hash") {
             match std::fs::write(&filepath, html) {
-                Ok(()) => println!("[build] {:?} {}", page_title, filepath.display()), 
+                Ok(()) => println!("[build] {:?} {}", page_title, filepath),
                 Err(err) => eprintln!("{:?}", err),
             }
         }
@@ -67,7 +67,12 @@ impl Writer {
         let html_header = Writer::header(state, slug);
 
         let callback = state.callback().0.get(&slug);
-        let footer_html = Writer::footer(section.metadata.footer_mode(), state, &section.references, callback);
+        let footer_html = Writer::footer(
+            section.metadata.footer_mode(),
+            state,
+            &section.references,
+            callback,
+        );
         let page_title = section.metadata.page_title().map_or("", |s| s.as_str());
 
         let html = crate::html_flake::html_doc(
@@ -96,7 +101,7 @@ impl Writer {
             .compiled()
             .get(&parent)
             .unwrap_or_else(|| panic!("missing slug `{:?}`", parent));
-        
+
         let href = config::full_html_url(parent);
         let title = section.metadata.title().map_or("", |s| s);
         let page_title = section.metadata.page_title().map_or("", |s| s);
@@ -104,7 +109,7 @@ impl Writer {
     }
 
     fn footer(
-        page_option: Option<FooterMode>, 
+        page_option: Option<FooterMode>,
         state: &CompileState,
         references: &HashSet<Slug>,
         callback: Option<&CallbackValue>,
@@ -170,7 +175,9 @@ impl Writer {
             config::FooterMode::Link => {
                 let summary = section.metadata.to_header(None, None);
                 let data_taxon = section.metadata.data_taxon().map_or("", |s| s);
-                format!(r#"<section class="block" data-taxon="{data_taxon}" style="margin-bottom: 0.4em;">{summary}</section>"#)
+                format!(
+                    r#"<section class="block" data-taxon="{data_taxon}" style="margin-bottom: 0.4em;">{summary}</section>"#
+                )
             }
             config::FooterMode::Embed => {
                 let contents = match !section.children.is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,15 +4,15 @@
 
 use std::{
     fs::{self, create_dir_all},
-    path::{Path, PathBuf},
     str::FromStr,
     sync::{LazyLock, OnceLock},
 };
 
+use camino::{Utf8Path, Utf8PathBuf};
 use eyre::Context;
 use serde::{Deserialize, Serialize};
 
-use crate::{config_toml::Config, slug::Slug};
+use crate::{config_toml::Config, path_utils, slug::Slug};
 
 #[derive(Debug, Clone, clap::ValueEnum, Default, Deserialize, Serialize)]
 pub enum FooterMode {
@@ -55,7 +55,7 @@ pub static TOML: OnceLock<String> = OnceLock::new();
 ///
 /// Please note that this value should always be automatically derived from
 /// the location of the toml configuration file.
-pub static ROOT: OnceLock<PathBuf> = OnceLock::new();
+pub static ROOT: OnceLock<Utf8PathBuf> = OnceLock::new();
 
 #[derive(Clone)]
 pub enum BuildMode {
@@ -100,7 +100,7 @@ pub fn to_page_suffix(pretty_urls: bool) -> String {
     page_suffix.into()
 }
 
-pub fn root_dir() -> PathBuf {
+pub fn root_dir() -> Utf8PathBuf {
     ROOT.get().unwrap().clone()
 }
 
@@ -112,16 +112,16 @@ pub fn is_short_slug() -> bool {
     CONFIG_TOML.get().unwrap().build.short_slug
 }
 
-pub fn typst_root_dir() -> PathBuf {
+pub fn typst_root_dir() -> Utf8PathBuf {
     CONFIG_TOML.get().unwrap().build.typst_root.clone().into()
 }
 
-pub fn trees_dir() -> PathBuf {
+pub fn trees_dir() -> Utf8PathBuf {
     let trees = &CONFIG_TOML.get().unwrap().kodama.trees;
     root_dir().join(trees)
 }
 
-pub fn output_dir() -> PathBuf {
+pub fn output_dir() -> Utf8PathBuf {
     let output_dir = match BUILD_MODE.get().unwrap() {
         BuildMode::Build => &CONFIG_TOML.get().unwrap().build.output,
         BuildMode::Serve => &CONFIG_TOML.get().unwrap().serve.output,
@@ -145,18 +145,18 @@ pub fn editor_url() -> Option<String> {
     CONFIG_TOML.get().unwrap().serve.edit.clone()
 }
 
-pub fn get_cache_dir() -> PathBuf {
+pub fn get_cache_dir() -> Utf8PathBuf {
     root_dir().join(CACHE_DIR_NAME)
 }
 
-pub fn assets_dir() -> PathBuf {
+pub fn assets_dir() -> Utf8PathBuf {
     let assets = &CONFIG_TOML.get().unwrap().kodama.assets;
     root_dir().join(assets)
 }
 
 /// URL keep posix style, so the type of return value is [`String`].
-pub fn full_url<P: AsRef<Path>>(path: P) -> String {
-    let path = crate::slug::pretty_path(path.as_ref());
+pub fn full_url<P: AsRef<Utf8Path>>(path: P) -> String {
+    let path = path_utils::pretty_path(path.as_ref());
     if let Some(stripped) = path.strip_prefix("/") {
         return format!("{}{}", base_url(), stripped);
     } else if let Some(stripped) = path.strip_prefix("./") {
@@ -171,28 +171,28 @@ pub fn full_html_url(slug: Slug) -> String {
     full_url(format!("{}{}", slug, page_suffix))
 }
 
-pub fn parent_dir<P: AsRef<Path>>(path: P) -> (PathBuf, PathBuf) {
+pub fn parent_dir<P: AsRef<Utf8Path>>(path: P) -> (Utf8PathBuf, Utf8PathBuf) {
     let binding = path.as_ref();
-    let filename = binding.file_name().expect("Path must have a filename");
-    let parent = binding.parent().expect("Path must have a parent");
+    let filename = binding.file_name().expect("Utf8Path must have a filename");
+    let parent = binding.parent().expect("Utf8Path must have a parent");
     (parent.to_path_buf(), filename.into())
 }
 
-pub fn input_path<P: AsRef<Path>>(path: P) -> PathBuf {
-    let mut filepath: PathBuf = trees_dir();
+pub fn input_path<P: AsRef<Utf8Path>>(path: P) -> Utf8PathBuf {
+    let mut filepath: Utf8PathBuf = trees_dir();
     filepath.push(path);
     filepath
 }
 
-pub fn create_parent_dirs<P: AsRef<Path>>(path: P) {
+pub fn create_parent_dirs<P: AsRef<Utf8Path>>(path: P) {
     let parent_dir = path.as_ref().parent().unwrap();
     if !parent_dir.exists() {
         let _ = create_dir_all(parent_dir);
     }
 }
 
-pub fn auto_create_dir_path<P: AsRef<Path>>(paths: Vec<P>) -> PathBuf {
-    let mut filepath: PathBuf = root_dir();
+pub fn auto_create_dir_path<P: AsRef<Utf8Path>>(paths: Vec<P>) -> Utf8PathBuf {
+    let mut filepath: Utf8PathBuf = root_dir();
     for path in paths {
         filepath.push(path);
     }
@@ -200,7 +200,7 @@ pub fn auto_create_dir_path<P: AsRef<Path>>(paths: Vec<P>) -> PathBuf {
     filepath
 }
 
-pub fn output_path<P: AsRef<Path>>(path: P) -> PathBuf {
+pub fn output_path<P: AsRef<Utf8Path>>(path: P) -> Utf8PathBuf {
     auto_create_dir_path(vec![&output_dir(), path.as_ref()])
 }
 
@@ -209,7 +209,7 @@ pub fn output_path<P: AsRef<Path>>(path: P) -> PathBuf {
 ///
 /// If the directory does not exist, it will be created.
 #[allow(dead_code)]
-pub fn output_html_path<P: AsRef<Path>>(path: P) -> PathBuf {
+pub fn output_html_path<P: AsRef<Utf8Path>>(path: P) -> Utf8PathBuf {
     let mut output_path = output_dir();
     output_path.push(path);
     output_path.set_extension("html");
@@ -217,7 +217,7 @@ pub fn output_html_path<P: AsRef<Path>>(path: P) -> PathBuf {
     output_path
 }
 
-pub fn hash_dir() -> PathBuf {
+pub fn hash_dir() -> Utf8PathBuf {
     get_cache_dir().join(HASH_DIR_NAME)
 }
 
@@ -225,18 +225,15 @@ pub fn hash_dir() -> PathBuf {
 /// e.g. `/path/to/index.md` will return `<hash_dir>/path/to/index.md.hash`.
 ///
 /// If the directory does not exist, it will be created.
-pub fn hash_file_path<P: AsRef<Path>>(path: P) -> PathBuf {
+pub fn hash_file_path<P: AsRef<Utf8Path>>(path: P) -> Utf8PathBuf {
     let mut hash_path = hash_dir();
     hash_path.push(path);
-    hash_path.set_extension(format!(
-        "{}.hash",
-        hash_path.extension().unwrap().to_str().unwrap()
-    ));
+    hash_path.set_extension(format!("{}.hash", hash_path.extension().unwrap()));
     create_parent_dirs(&hash_path);
     hash_path
 }
 
-pub fn entry_dir() -> PathBuf {
+pub fn entry_dir() -> Utf8PathBuf {
     get_cache_dir().join(ENTRY_DIR_NAME)
 }
 
@@ -244,24 +241,21 @@ pub fn entry_dir() -> PathBuf {
 /// e.g. `/path/to/index.md` will return `<entry_dir>/path/to/index.md.entry`.
 ///
 /// If the directory does not exist, it will be created.
-pub fn entry_file_path<P: AsRef<Path>>(path: P) -> PathBuf {
+pub fn entry_file_path<P: AsRef<Utf8Path>>(path: P) -> Utf8PathBuf {
     let mut entry_path = entry_dir();
     entry_path.push(path);
-    entry_path.set_extension(format!(
-        "{}.entry",
-        entry_path.extension().unwrap().to_str().unwrap()
-    ));
+    entry_path.set_extension(format!("{}.entry", entry_path.extension().unwrap()));
     create_parent_dirs(&entry_path);
     entry_path
 }
 
 /// Return is file modified i.e. is hash updated.
-pub fn is_hash_updated<P: AsRef<Path>>(content: &str, hash_path: P) -> (bool, u64) {
+pub fn is_hash_updated<P: AsRef<Utf8Path>>(content: &str, hash_path: P) -> (bool, u64) {
     let mut hasher = std::hash::DefaultHasher::new();
     std::hash::Hash::hash(&content, &mut hasher);
     let current_hash = std::hash::Hasher::finish(&hasher);
 
-    let history_hash = std::fs::read_to_string(&hash_path)
+    let history_hash = std::fs::read_to_string(hash_path.as_ref())
         .map(|s| s.parse::<u64>().expect("Invalid hash"))
         .unwrap_or(0); // no file: 0
 
@@ -270,24 +264,27 @@ pub fn is_hash_updated<P: AsRef<Path>>(content: &str, hash_path: P) -> (bool, u6
 
 /// Checks whether the file has been modified by comparing its current hash with the stored hash.
 /// If the file is modified, updates the stored hash to reflect the latest state.
-pub fn verify_and_file_hash<P: AsRef<Path>>(relative_path: P) -> eyre::Result<bool> {
+pub fn verify_and_file_hash<P: AsRef<Utf8Path>>(relative_path: P) -> eyre::Result<bool> {
     let root_dir = trees_dir();
     let full_path = root_dir.join(&relative_path);
     let hash_path = hash_file_path(&relative_path);
 
     let content = std::fs::read_to_string(&full_path)
-        .wrap_err_with(|| eyre::eyre!("failed to read file `{}`", full_path.display()))?;
+        .wrap_err_with(|| eyre::eyre!("failed to read file `{}`", full_path))?;
     let (is_modified, current_hash) = is_hash_updated(&content, &hash_path);
     if is_modified {
         std::fs::write(&hash_path, current_hash.to_string())
-            .wrap_err_with(|| eyre::eyre!("failed to write file `{}`", hash_path.display()))?;
+            .wrap_err_with(|| eyre::eyre!("failed to write file `{}`", hash_path))?;
     }
     Ok(is_modified)
 }
 
 /// Checks whether the content has been modified by comparing its current hash with the stored hash.
 /// If the content is modified, updates the stored hash to reflect the latest state.
-pub fn verify_update_hash<P: AsRef<Path>>(path: P, content: &str) -> Result<bool, std::io::Error> {
+pub fn verify_update_hash<P: AsRef<Utf8Path>>(
+    path: P,
+    content: &str,
+) -> Result<bool, std::io::Error> {
     let hash_path = hash_file_path(path.as_ref());
     let (is_modified, current_hash) = is_hash_updated(content, &hash_path);
     if is_modified {

--- a/src/config_toml.rs
+++ b/src/config_toml.rs
@@ -1,9 +1,8 @@
 // Copyright (c) 2025 Kodama Project. All rights reserved.
 // Released under the GPL-3.0 license as described in the file LICENSE.
-// Authors: Kokic (@kokic)
+// Authors: Kokic (@kokic), Spore (@s-cerevisiae)
 
-use std::path::PathBuf;
-
+use camino::Utf8PathBuf;
 use serde::{Deserialize, Serialize};
 
 use crate::config::{self, FooterMode};
@@ -87,19 +86,16 @@ fn parse_config(config: &str) -> eyre::Result<Config> {
     Ok(config)
 }
 
-pub fn apply_config(toml_file: PathBuf) -> eyre::Result<()> {
+pub fn apply_config(toml_file: Utf8PathBuf) -> eyre::Result<()> {
     // Try find toml file in the current directory or the parent directory.
     let mut toml_file = toml_file;
     if !toml_file.exists() {
-        let parent = toml_file.parent().unwrap().canonicalize()?;
+        let parent = toml_file.parent().unwrap().canonicalize_utf8()?;
         let parent = parent.parent().unwrap();
 
         toml_file = parent.join(DEFAULT_CONFIG_PATH);
         if !toml_file.exists() {
-            return Err(eyre::eyre!(
-                "cannot find configuration file: {}",
-                toml_file.display()
-            ));
+            return Err(eyre::eyre!("cannot find configuration file: {}", toml_file));
         }
     }
 
@@ -109,7 +105,7 @@ pub fn apply_config(toml_file: PathBuf) -> eyre::Result<()> {
     let toml = std::fs::read_to_string(&toml_file)?;
 
     let _ = config::ROOT.set(root.to_path_buf());
-    let _ = config::TOML.set(toml_file.file_name().unwrap().to_str().unwrap().to_string());
+    let _ = config::TOML.set(toml_file.file_name().unwrap().to_owned());
     let _ = config::CONFIG_TOML.set(parse_config(&toml)?);
     Ok(())
 }

--- a/src/path_utils.rs
+++ b/src/path_utils.rs
@@ -2,16 +2,30 @@
 // Released under the GPL-3.0 license as described in the file LICENSE.
 // Authors: Spore (@s-cerevisiae)
 
-use std::path::{Path, PathBuf};
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 
-pub fn relative_to_current<P1, P2>(current: P1, target: P2) -> PathBuf
+pub fn relative_to_current<P1, P2>(current: P1, target: P2) -> Utf8PathBuf
 where
-    P1: AsRef<Path>,
-    P2: AsRef<Path>,
+    P1: AsRef<Utf8Path>,
+    P2: AsRef<Utf8Path>,
 {
     if let Some(parent) = current.as_ref().parent() {
         parent.join(target)
     } else {
         target.as_ref().to_owned()
     }
+}
+
+pub fn pretty_path(path: &Utf8Path) -> String {
+    let mut segments = Vec::new();
+    for c in path.components() {
+        match c {
+            Utf8Component::Prefix(_) | Utf8Component::RootDir | Utf8Component::CurDir => (),
+            Utf8Component::ParentDir => {
+                segments.pop();
+            }
+            Utf8Component::Normal(_) => segments.push(c.as_str()),
+        }
+    }
+    segments.join("/")
 }

--- a/src/process/typst_image.rs
+++ b/src/process/typst_image.rs
@@ -2,7 +2,10 @@
 // Released under the GPL-3.0 license as described in the file LICENSE.
 // Authors: Kokic (@kokic), Spore (@s-cerevisiae)
 
-use std::{fmt::Write, fs, path::PathBuf};
+use std::{fmt::Write, fs};
+
+use camino::Utf8PathBuf;
+use pulldown_cmark::{Event, Tag, TagEnd};
 
 use crate::{
     config::{self, output_path, parent_dir},
@@ -12,7 +15,6 @@ use crate::{
     slug::Slug,
     typst_cli::{self, write_svg, write_to_inline_html, InlineConfig},
 };
-use pulldown_cmark::{Event, Tag, TagEnd};
 
 use super::processer::url_action;
 
@@ -191,7 +193,7 @@ impl<'e, E: Iterator<Item = Event<'e>>> Iterator for TypstImage<E> {
 
                         let root_dir = config::trees_dir();
                         let full_path = root_dir.join(typst_url);
-                        let code = fs::read_to_string(format!("{}.code", full_path.display()))
+                        let code = fs::read_to_string(format!("{}.code", full_path))
                             .unwrap_or_else(|_| fs::read_to_string(full_path).unwrap());
 
                         let html = html_figure_code(&config::full_url(&img_src), caption, code);
@@ -234,7 +236,7 @@ pub fn is_inline_typst(dest_url: &str) -> bool {
     dest_url == key || dest_url.starts_with(&format!("{}-", key))
 }
 
-fn typst_path(current_slug: Slug, url: &str) -> PathBuf {
+fn typst_path(current_slug: Slug, url: &str) -> Utf8PathBuf {
     let path = path_utils::relative_to_current(current_slug.as_str(), url);
     if let Ok(rest) = path.strip_prefix("/") {
         rest.to_owned()

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -2,10 +2,13 @@
 // Released under the GPL-3.0 license as described in the file LICENSE.
 // Authors: Kokic (@kokic), Spore (@s-cerevisiae)
 
-use std::{fmt::Display, path::Path, str::FromStr};
+use std::{fmt::Display, str::FromStr};
 
+use camino::Utf8Path;
 use internment::Intern;
 use serde::{Deserialize, Serialize};
+
+use crate::path_utils;
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Slug(Intern<str>);
@@ -96,31 +99,7 @@ pub fn to_hash_id(slug_str: &str) -> String {
     slug_str.replace("/", "-")
 }
 
-pub fn to_slug<P: AsRef<Path>>(path: P) -> Slug {
+pub fn to_slug<P: AsRef<Utf8Path>>(path: P) -> Slug {
     let path = path.as_ref();
-    Slug::new(pretty_path(&path.with_extension("")))
-}
-
-pub fn pretty_path(path: &std::path::Path) -> String {
-    posix_style(clean_path(path).to_str().unwrap())
-}
-
-pub fn posix_style(s: &str) -> String {
-    s.replace("\\", "/")
-}
-
-fn clean_path(path: &std::path::Path) -> std::path::PathBuf {
-    let mut cleaned_path = std::path::PathBuf::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::RootDir | std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                cleaned_path.pop();
-            }
-            _ => {
-                cleaned_path.push(component.as_os_str());
-            }
-        }
-    }
-    cleaned_path
+    Slug::new(path_utils::pretty_path(&path.with_extension("")))
 }

--- a/src/typst_cli.rs
+++ b/src/typst_cli.rs
@@ -2,18 +2,23 @@
 // Released under the GPL-3.0 license as described in the file LICENSE.
 // Authors: Kokic (@kokic), Spore (@s-cerevisiae)
 
-use std::{fs, io::Write, path::Path, process::Command};
+use std::{fs, io::Write, process::Command};
+
+use camino::Utf8Path;
 
 use crate::{
     config::{self, verify_and_file_hash},
-    html_flake,
+    html_flake, path_utils,
 };
 
-pub fn write_to_inline_html<P: AsRef<Path>>(typst_path: P, html_path: P) -> eyre::Result<String> {
-    if !verify_and_file_hash(typst_path.as_ref())? && Path::new(html_path.as_ref()).exists() {
-        let existed_html = fs::read_to_string(html_path)?;
+pub fn write_to_inline_html<P: AsRef<Utf8Path>>(
+    typst_path: P,
+    html_path: P,
+) -> eyre::Result<String> {
+    if !verify_and_file_hash(typst_path.as_ref())? && html_path.as_ref().exists() {
+        let existed_html = fs::read_to_string(html_path.as_ref())?;
         let existed_html = html_to_body_content(&existed_html);
-        println!("Skip: {}", crate::slug::pretty_path(typst_path.as_ref()));
+        println!("Skip: {}", path_utils::pretty_path(typst_path.as_ref()));
         return Ok(existed_html);
     }
 
@@ -21,10 +26,10 @@ pub fn write_to_inline_html<P: AsRef<Path>>(typst_path: P, html_path: P) -> eyre
     let html = to_html_string(typst_path.as_ref(), &root_dir)?;
     let html_body = html_to_body_content(&html);
 
-    fs::write(&html_path, html)?;
+    fs::write(html_path.as_ref(), html)?;
     println!(
         "Compiled to HTML: {}",
-        crate::slug::pretty_path(html_path.as_ref())
+        path_utils::pretty_path(html_path.as_ref())
     );
 
     Ok(html_body)
@@ -66,7 +71,7 @@ pub fn file_to_html(rel_path: &str, root_dir: &str) -> eyre::Result<String> {
     to_html_string(rel_path, root_dir).map(|s| html_to_body_content(&s))
 }
 
-fn to_html_string<P: AsRef<Path>>(rel_path: P, root_dir: P) -> eyre::Result<String> {
+fn to_html_string<P: AsRef<Utf8Path>>(rel_path: P, root_dir: P) -> eyre::Result<String> {
     let root_dir = root_dir.as_ref();
     let rel_path = rel_path.as_ref();
     let full_path = root_dir.join(rel_path);
@@ -75,8 +80,8 @@ fn to_html_string<P: AsRef<Path>>(rel_path: P, root_dir: P) -> eyre::Result<Stri
         .arg("c")
         .arg("-f=html")
         .arg("--features=html")
-        .arg(format!("--root={}", root_dir.to_string_lossy()))
-        .args(["--input", &format!("path={}", rel_path.to_string_lossy())])
+        .arg(format!("--root={}", root_dir))
+        .args(["--input", &format!("path={}", rel_path)])
         .args(["--input", &format!("random={}", fastrand::i64(0..))])
         .arg(full_path)
         .arg("-")
@@ -88,11 +93,7 @@ fn to_html_string<P: AsRef<Path>>(rel_path: P, root_dir: P) -> eyre::Result<Stri
         stdout.to_string()
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        failed_in_file(
-            concat!(file!(), '#', line!()),
-            rel_path.to_str().unwrap(),
-            stderr,
-        );
+        failed_in_file(concat!(file!(), '#', line!()), rel_path.as_str(), stderr);
         String::new()
     })
 }
@@ -103,7 +104,7 @@ fn source_to_svg(src: &str) -> eyre::Result<String> {
     let mut typst = Command::new("typst")
         .arg("c")
         .arg("-f=svg")
-        .arg(format!("--root={}", root_dir.to_string_lossy()))
+        .arg(format!("--root={}", root_dir))
         .arg("-")
         .arg("-")
         .stdin(std::process::Stdio::piped())
@@ -127,12 +128,12 @@ fn source_to_svg(src: &str) -> eyre::Result<String> {
     })
 }
 
-pub fn write_svg<P: AsRef<Path>>(typst_path: P, svg_path: P) -> eyre::Result<()> {
+pub fn write_svg<P: AsRef<Utf8Path>>(typst_path: P, svg_path: P) -> eyre::Result<()> {
     let typst_path = typst_path.as_ref();
     let svg_path = svg_path.as_ref();
 
     if !verify_and_file_hash(typst_path)? && svg_path.exists() {
-        println!("Skip: {}", crate::slug::pretty_path(typst_path));
+        println!("Skip: {}", path_utils::pretty_path(typst_path));
         return Ok(());
     }
 
@@ -141,7 +142,7 @@ pub fn write_svg<P: AsRef<Path>>(typst_path: P, svg_path: P) -> eyre::Result<()>
     let output = Command::new("typst")
         .arg("c")
         .arg("-f=svg")
-        .arg(format!("--root={}", root_dir.to_string_lossy()))
+        .arg(format!("--root={}", root_dir))
         .arg(&full_path)
         .arg(svg_path)
         .output()?;
@@ -149,15 +150,11 @@ pub fn write_svg<P: AsRef<Path>>(typst_path: P, svg_path: P) -> eyre::Result<()>
     if output.status.success() {
         println!(
             "Compiled to SVG: {}",
-            crate::slug::pretty_path(Path::new(svg_path))
+            path_utils::pretty_path(Utf8Path::new(svg_path))
         );
     } else {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        failed_in_file(
-            concat!(file!(), '#', line!()),
-            full_path.to_str().unwrap(),
-            stderr,
-        );
+        failed_in_file(concat!(file!(), '#', line!()), full_path.as_str(), stderr);
     }
     Ok(())
 }


### PR DESCRIPTION
This replaces all `Path` related types with `camino::Utf8Path` series. Now we need less `display`s and `unwrap`s.

Closes #46.