### PR TITLE
fix(config::test::test_empty_toml): default for inline_css

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -68,7 +68,7 @@ mod test {
         assert_eq!(config.kodama.base_url, "/");
         assert!(!config.build.short_slug);
         assert!(!config.build.pretty_urls);
-        assert!(!config.build.inline_css);
+        assert!(config.build.inline_css);
         assert_eq!(config.serve.edit, serve.edit);
         assert_eq!(config.serve.output, serve.output);
     }


### PR DESCRIPTION
When the default changed in e94b8f140941971c7b4663b21d58b61ff04aa692, the test wasn't updated.