### PR TITLE
fix(minor): make `split_file_name` more consistent across platforms

### DIFF
--- a/src/path_utils.rs
+++ b/src/path_utils.rs
@@ -31,10 +31,7 @@ pub fn pretty_path(path: &Utf8Path) -> String {
 }
 
 pub fn split_file_name(path: &Utf8Path) -> Option<(&Utf8Path, &str)> {
-    let mut components = path.components();
-    let name = components.next_back();
-    let base = components.as_path();
-    Some((base, name?.as_str()))
+    path.parent().zip(path.file_name())
 }
 
 #[cfg(test)]
@@ -43,9 +40,9 @@ mod tests {
 
     #[test]
     fn test_split_base() {
-        assert_eq!(split_file_name("a/b".into()), Some(("a".into(), "b")));
+        assert_eq!(split_file_name("a/b.c".into()), Some(("a".into(), "b.c")));
         assert_eq!(split_file_name("a/b/c".into()), Some(("a/b".into(), "c")));
-        assert_eq!(split_file_name("/".into()), Some(("".into(), "/")));
         assert_eq!(split_file_name("a".into()), Some(("".into(), "a")));
+        assert_eq!(split_file_name("/".into()), None);
     }
 }


### PR DESCRIPTION
Now it doesn't see `/` as a file name. Please test if this change in behavior result in any problems.